### PR TITLE
Add provision of CI host

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,4 +64,5 @@ target/
 tags
 
 .vagrant
-devenv/main.retry
+devenv/galaxy
+devenv/*.retry

--- a/devenv/jenkins.inventory
+++ b/devenv/jenkins.inventory
@@ -1,0 +1,1 @@
+cephlcm-ci ansible_host=172.18.191.83 ansible_user=ubuntu

--- a/devenv/jenkins.yaml
+++ b/devenv/jenkins.yaml
@@ -1,0 +1,15 @@
+---
+# Base playbook to deploy jenkins host
+
+
+- name: Install Jenkins
+  hosts: cephlcm-ci
+  become: true
+  roles:
+    - role: geerlingguy.jenkins
+
+- name: Install base CI
+  hosts: cephlcm-ci
+  roles:
+    - ci
+    - mongodb

--- a/devenv/requirements.yaml
+++ b/devenv/requirements.yaml
@@ -1,2 +1,4 @@
 ---
 # A list of ansible-galaxy roles to install
+
+- src: geerlingguy.jenkins

--- a/devenv/roles/ci/tasks/main.yaml
+++ b/devenv/roles/ci/tasks/main.yaml
@@ -1,0 +1,26 @@
+---
+# Base setup for CI
+
+
+- name: Install aptitude for Ansible
+  become: true
+  command: apt-get install -y aptitude
+
+- name: Ensure host OS is up to date
+  become: true
+  apt: update_cache=yes upgrade=safe
+
+- name: Ensure required packages are installed
+  become: true
+  apt: name={{ item }} state=latest
+  with_items: "{{ apt_packages }}"
+
+- name: Ensure that users have SSH keys
+  become: true
+  user: name={{ item }}
+        generate_ssh_key=yes
+        ssh_key_bits=4096
+        ssh_key_file=.ssh/id_rsa
+  with_items:
+    - jenkins
+    - "{{ ansible_user }}"

--- a/devenv/roles/ci/vars/main.yaml
+++ b/devenv/roles/ci/vars/main.yaml
@@ -1,0 +1,17 @@
+---
+# Vars for CI
+
+
+apt_packages:
+  - htop
+  - python3
+  - python3-dev
+  - python3-pip
+  - python3-virtualenv
+  - python-dev
+  - python-pip
+  - tox
+  - vim
+  - virtualenv
+
+tox_version: 2.3.1


### PR DESCRIPTION
To provision another host, do following:
1. Modify `devenv/jenkins.inventory` and put proper host here
2. Execute following shell script
   
   ``` shell
   $ ansible-galaxy install -r devenv/requirements.yaml -p devenv/galaxy
   $ ansible-playbook -i devenv/jenkins.inventory devenv/jenkins.yaml
   ```

After that proceed to Jenkins and create following pipeline:

``` groovy
node {
   try {
      stage 'Checkout SCM'
      checkout(
          [
              $class: 'GitSCM',
              branches: [[name: '*/master']],
              doGenerateSubmoduleConfigurations: false,
              extensions: [],
              submoduleCfg: [],
              userRemoteConfigs: [[credentialsId: '<your id>', url: 'git@github.com:Mirantis/ceph-lcm.git']]
           ]
       )

      stage 'Run tests'
      sh 'tox -e test'

      stage 'Run static analysis'
      parallel(
          "linters": {
              echo 'Run linters'
              sh 'tox -e static'
          },
          "metrics": {
              echo 'Run code complexity analysis'
              sh 'tox -e metrics'
          }
      )
   } catch (any) {
      emailext body: "See ${env.BUILD_URL}",
               recipientProviders: [[$class: 'CulpritsRecipientProvider'], [$class: 'RequesterRecipientProvider'], [$class: 'FailingTestSuspectsRecipientProvider'], [$class: 'FirstFailingBuildSuspectsRecipientProvider']],
               subject: "CephLCM CI: ${env.JOB_NAME} ${env.BUILD_NUMBER} is failed.",
               to: '<whom to send>'
      throw any
   }
}
```
