### PR TITLE
Consistent API responses

### DIFF
--- a/cephlcm/api/views/v1/permission.py
+++ b/cephlcm/api/views/v1/permission.py
@@ -18,4 +18,9 @@ class PermissionView(generic.ModelView):
     ENDPOINT = "/permission/"
 
     def get(self):
-        return role.PermissionSet(role.PermissionSet.KNOWN_PERMISSIONS)
+        permissions = role.PermissionSet(role.PermissionSet.KNOWN_PERMISSIONS)
+        permissions = permissions.make_api_structure()
+        permissions = [
+            {"name": k, "permissions": v} for k, v in permissions.items()]
+
+        return {"items": permissions}

--- a/cephlcm/api/views/v1/playbook.py
+++ b/cephlcm/api/views/v1/playbook.py
@@ -41,4 +41,4 @@ class PlaybookView(generic.ModelView):
             }
             data.append(plugin_data)
 
-        return {"playbooks": sorted(data, key=lambda elem: elem["name"])}
+        return {"items": sorted(data, key=lambda elem: elem["name"])}

--- a/tests/api/views/v1/test_api_permission.py
+++ b/tests/api/views/v1/test_api_permission.py
@@ -10,7 +10,11 @@ def test_access_ok(sudo_client_v1):
     response = sudo_client_v1.get("/v1/permission/")
 
     assert response.status_code == 200
-    assert pset.make_api_structure() == response.json
+    assert isinstance(response.json["items"], list)
+
+    items = {item["name"]: item["permissions"]
+             for item in response.json["items"]}
+    assert pset.make_api_structure() == items
 
 
 def test_access_authentication(client_v1):

--- a/tests/api/views/v1/test_api_playbook.py
+++ b/tests/api/views/v1/test_api_playbook.py
@@ -24,7 +24,7 @@ def test_playbook_list(sudo_client_v1):
 
     assert response.status_code == 200
     for plugin in list_of_plugins:
-        for data in response.json["playbooks"]:
+        for data in response.json["items"]:
             if plugin.name == data["name"]:
                 assert plugin.DESCRIPTION == data["description"]
                 assert plugin.REQUIRED_SERVER_LIST == \


### PR DESCRIPTION
`/v1/permission` and '/v1/playbook' API endpoints return `{"items": [...]}` response now. Precisely, `/v1/permission` returns `{"items": [{"name": "api", "permissions": [...]}, ...]}` response now.