### PR TITLE
cloud-init server discovery

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,7 +8,7 @@ require 'tempfile'
 VAGRANTFILE_API_VERSION = "2"
 
 CLOUD_CONFIG_USERNAME = "ansible"
-CLOUD_CONFIG_URL = "http://10.0.0.10:5000/v1/server/"
+CLOUD_CONFIG_URL = "http://10.0.0.10:8000/v1/server/"
 CLOUD_CONFIG_KEY = "~/.ssh/id_rsa.pub"
 CLOUD_CONFIG_TOKEN = "26758c32-3421-4f3d-9603-e4b5337e7ecc"
 CLOUD_CONFIG_GEN = File.dirname(__FILE__) + "/cephlcmlib/cephlcmlib/cli/cloud_config.py"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -75,7 +75,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.vm.define "#{host}", autostart: false do |client|
       client.vm.box = "ubuntu/trusty64"
       client.vm.hostname = "ceph-#{host}"
-      client.vm.network "private_network", ip: "10.1.0.1#{idx}"
+      client.vm.network "private_network", ip: "10.0.0.2#{idx}"
 
       # http://foo-o-rama.com/vagrant--stdin-is-not-a-tty--fix.html
       client.vm.provision "fix-no-tty", type: "shell" do |s|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,9 +11,10 @@ CLOUD_CONFIG_USERNAME = "ansible"
 CLOUD_CONFIG_URL = "http://10.0.0.10:5000/v1/server/"
 CLOUD_CONFIG_KEY = "~/.ssh/id_rsa.pub"
 CLOUD_CONFIG_TOKEN = "26758c32-3421-4f3d-9603-e4b5337e7ecc"
-CLOUD_CONFIG_CONTENT = `python3 scripts/generate_cloud_config.py -d -k #{CLOUD_CONFIG_KEY} -u #{CLOUD_CONFIG_USERNAME} #{CLOUD_CONFIG_URL} #{CLOUD_CONFIG_TOKEN}`
-
+CLOUD_CONFIG_GEN = File.dirname(__FILE__) + "/cephlcmlib/cephlcmlib/cli/cloud_config.py"
 CLOUD_CONFIG_FILE = Tempfile::new("cloud_config")
+CLOUD_CONFIG_CONTENT = `#{CLOUD_CONFIG_GEN} -d -k #{CLOUD_CONFIG_KEY} -u #{CLOUD_CONFIG_USERNAME} #{CLOUD_CONFIG_URL} #{CLOUD_CONFIG_TOKEN}`
+
 begin
   CLOUD_CONFIG_FILE.write CLOUD_CONFIG_CONTENT
   CLOUD_CONFIG_FILE.close

--- a/backend/api/cephlcm_api/views/v1/server.py
+++ b/backend/api/cephlcm_api/views/v1/server.py
@@ -77,8 +77,6 @@ def require_create_server_authorization(func):
 class ServerView(generic.VersionedCRUDView):
     """Implementation of view for /v1/server/."""
 
-    decorators = [auth.require_authentication]
-
     NAME = "server"
     MODEL_NAME = "server"
     ENDPOINT = "/server/"

--- a/backend/api/cephlcm_api/wsgi.py
+++ b/backend/api/cephlcm_api/wsgi.py
@@ -1,8 +1,0 @@
-# -*- coding: utf-8 -*-
-"""This module has instance of WSGI application."""
-
-
-import cephlcm_api
-
-
-app = application = cephlcm_api.create_application()

--- a/backend/api/setup.cfg
+++ b/backend/api/setup.cfg
@@ -28,6 +28,10 @@ packages =
 setup-hooks =
   pbr.hooks.setup_hook
 
+[entry_points]
+wsgi_scripts =
+  cephlcm-api = cephlcm_api:create_application
+
 [pbr]
 warnerrors = true
 

--- a/backend/common/cephlcm_common/configs/defaults.toml
+++ b/backend/common/cephlcm_common/configs/defaults.toml
@@ -76,6 +76,7 @@ json_sort_keys = true
 jsonify_prettyprint_regular = true
 json_as_ascii = false
 pagination_per_page = 25
+server_discovery_token = "26758c32-3421-4f3d-9603-e4b5337e7ecc"
 
     # API options related to tokens
     [api.token]

--- a/cephlcmlib/cephlcmlib/cli/__init__.py
+++ b/cephlcmlib/cephlcmlib/cli/__init__.py
@@ -103,11 +103,11 @@ def cli_group(func):
     return func
 
 
-from cephlcmlib.cli import cluster # NOQA
-from cephlcmlib.cli import execution # NOQA
-from cephlcmlib.cli import permission # NOQA
-from cephlcmlib.cli import playbook_configuration # NOQA
-from cephlcmlib.cli import playbook # NOQA
-from cephlcmlib.cli import role # NOQA
-from cephlcmlib.cli import server # NOQA
-from cephlcmlib.cli import user # NOQA
+from cephlcmlib.cli import cluster  # NOQA
+from cephlcmlib.cli import execution  # NOQA
+from cephlcmlib.cli import permission  # NOQA
+from cephlcmlib.cli import playbook  # NOQA
+from cephlcmlib.cli import playbook_configuration  # NOQA
+from cephlcmlib.cli import role  # NOQA
+from cephlcmlib.cli import server  # NOQA
+from cephlcmlib.cli import user  # NOQA

--- a/cephlcmlib/cephlcmlib/cli/cloud_config.py
+++ b/cephlcmlib/cephlcmlib/cli/cloud_config.py
@@ -20,13 +20,16 @@ UUID_FILENAME = "/tmp/__uuid__"
 DEFAULT_USER = "ansible"
 """Default user for Ansible."""
 
+REQUEST_TIMEOUT = 5  # seconds
+"""How long to wait for response from API."""
+
 PYTHON_PROG = """
 import json,urllib2
 d={{"username":{username!r},"host":open({ip_filename!r}).read(),"id":open({uuid_filename!r}).read()}}
 r=urllib2.Request({url!r},json.dumps(d))
 r.add_header("Content-Type","application/json")
 r.add_header("Authorization",{token!r})
-print(urllib2.urlopen(r).read())
+print(urllib2.urlopen(r,timeout={timeout}).read())
 """.strip()
 """Python program to use instead of Curl."""
 
@@ -124,7 +127,8 @@ def get_command_notify(options):
         ip_filename=IP_FILENAME,
         uuid_filename=UUID_FILENAME,
         url=url,
-        token=str(options.token)
+        token=str(options.token),
+        timeout=options.timeout
     )
     program = ";".join(program.split("\n"))
 
@@ -196,6 +200,13 @@ def get_options():
     parser.add_argument(
         "-g", "--group",
         help="Group of Ansible user to use. Default is given username."
+    )
+    parser.add_argument(
+        "-t", "--timeout",
+        type=int,
+        default=REQUEST_TIMEOUT,
+        help="Timeout to access API in seconds. Default is {0}.".format(
+            REQUEST_TIMEOUT)
     )
     parser.add_argument(
         "-d", "--debug",

--- a/cephlcmlib/cephlcmlib/cli/cloud_config.py
+++ b/cephlcmlib/cephlcmlib/cli/cloud_config.py
@@ -1,12 +1,12 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 
 import argparse
 import json
-import shlex
 import sys
 
+import six.moves
 import yaml
 
 
@@ -91,7 +91,7 @@ def get_command_clean(options):
 
 def get_curl_command(options):
     request = get_request_data(options)
-    request = shlex.quote(request)
+    request = six.moves.shlex_quote(request)
 
     command = ["curl"]
     if options.debug:

--- a/cephlcmlib/requirements.txt
+++ b/cephlcmlib/requirements.txt
@@ -2,5 +2,6 @@
 
 click
 jsonpatch
+PyYAML
 requests[socks]
 six

--- a/cephlcmlib/setup.cfg
+++ b/cephlcmlib/setup.cfg
@@ -29,6 +29,7 @@ packages =
 [entry_points]
 console_scripts =
   cephlcm = cephlcmlib.cli:cli
+  cephlcm-cloud-config = cephlcmlib.cli.cloud_config:main
 
 [global]
 setup-hooks =

--- a/constraints.txt
+++ b/constraints.txt
@@ -40,6 +40,7 @@ pytest-cov==2.3.1
 pytest-fauxfactory==1.0
 pytest-flask==0.10.0
 pytest-profiling==1.1.1
+PyYAML==3.12
 radon==1.4.2
 requests==2.11.0
 see==1.3.2

--- a/optional-requirements.txt
+++ b/optional-requirements.txt
@@ -3,6 +3,7 @@
 # Cannot use it here because pbr still do not understand such line.
 # -c constraints.txt
 
-ipython
 ipdb
+ipython
+PyYAML
 see

--- a/optional-requirements.txt
+++ b/optional-requirements.txt
@@ -5,5 +5,4 @@
 
 ipdb
 ipython
-PyYAML
 see

--- a/scripts/generate_cloud_config.py
+++ b/scripts/generate_cloud_config.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+
+import argparse
+import json
+import shlex
+import sys
+
+import yaml
+
+
+IP_FILENAME = "/tmp/__ip__"
+"""Temporary filename to store default IP address."""
+
+UUID_FILENAME = "/tmp/__uuid__"
+"""Temporary filename to store machine UUID."""
+
+
+def main():
+    options = get_options()
+    document = {
+        "users": get_users(options),
+        "packages": get_packages(options),
+        "bootcmd": get_bootcmd(options)
+    }
+
+    print("#cloud-config")
+    print(yaml.dump(document, indent=2, width=9999))
+
+
+def get_users(options):
+    return [
+        {
+            "name": options.username,
+            "groups": ["sudo", options.group or options.username],
+            "shell": "/bin/bash",
+            "sudo": ["ALL=(ALL) NOPASSWD:ALL"],
+            "ssh-authorized-keys": [options.public_key.read().strip()]
+        }
+    ]
+
+
+def get_packages(options):
+    return [
+        "dmidecode",
+        "iproute2",
+        "curl"
+    ]
+
+
+def get_bootcmd(options):
+    return [
+        get_command_uuid(options),
+        get_command_ip(options),
+        get_command_all(options),
+        get_command_clean(options)
+    ]
+
+
+def get_command_uuid(options):
+    return [
+        "sh", "-c",
+        "dmidecode | grep UUID | rev | cut -f1 -d' ' | rev | "
+        "tr -d '[[:space:]]' | tr '[[:upper:]]' '[[:lower:]]' > {0}".format(
+            UUID_FILENAME)
+    ]
+
+
+def get_command_ip(options):
+    return [
+        "sh", "-c",
+        "ip r g 8.8.8.8 | head -n1 | rev | cut -f2 -d' ' | rev | "
+        "tr -d '[[:space:]]' > {0}".format(IP_FILENAME)
+    ]
+
+
+def get_command_all(options):
+    return ["sh", "-cx", get_curl_command(options)]
+
+
+def get_command_clean(options):
+    return ["rm", UUID_FILENAME, IP_FILENAME]
+
+
+def get_curl_command(options):
+    request = get_request_data(options)
+    request = shlex.quote(request)
+
+    command = ["curl"]
+    command.append("--silent")
+    command.append("--location")
+    command.extend(["--request", "POST"])
+    command.extend(["--header", "'Authorization: {0}'".format(options.token)])
+    command.extend(["--header", "'Content-Type: application/json'"])
+    command.extend(["--data", request])
+    command.append(options.url)
+
+    return " ".join(command)
+
+
+def get_request_data(options):
+    data = {
+        "id": "$(cat {0})".format(UUID_FILENAME),
+        "username": options.username,
+        "host": "$(cat {0})".format(IP_FILENAME)
+    }
+    data = json.dumps(data, separators=(",", ":"))
+
+    return data
+
+
+def get_options():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "url",
+        help="URL of CephLCM API."
+    )
+    parser.add_argument(
+        "token",
+        help="Server token."
+    )
+    parser.add_argument(
+        "-k", "--public-key",
+        help=(
+            "Path to the public key file. If nothing is provided, then "
+            "stdin will be used as a source."
+        ),
+        default=sys.stdin,
+        nargs="?",
+        type=argparse.FileType("r")
+    )
+    parser.add_argument(
+        "-u", "--username",
+        help="Username for Ansible to use.",
+        default="ansible"
+    )
+    parser.add_argument(
+        "-g", "--group",
+        help="Group of Ansible user to use."
+    )
+
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/api/views/v1/test_api_server.py
+++ b/tests/api/views/v1/test_api_server.py
@@ -6,6 +6,7 @@ import copy
 
 import pytest
 
+from cephlcm_common import config
 from cephlcm_common.models import server
 from cephlcm_common.models import task
 
@@ -119,6 +120,24 @@ def test_post_server(host, client_v1, normal_user, sudo_client_v1,
 
     servers = pymongo_connection.db.server.find({})
     assert servers.count() == 0
+
+
+def test_post_server_server_discovery_token(client_v1, pymongo_connection):
+    request = {
+        "id": pytest.faux.gen_uuid(),
+        "host": pytest.faux.gen_alphanumeric(),
+        "username": pytest.faux.gen_alpha()
+    }
+
+    conf = config.make_api_config()
+    client_v1.auth_token = conf.API_SERVER_DISCOVERY_TOKEN
+    response = client_v1.post("/v1/server/", data=request)
+    assert response.status_code == 200
+    assert response.json == {}
+
+    found_task = pymongo_connection.db.task.find_one(
+        {"data.host": request["host"]})
+    assert found_task
 
 
 def test_update_server(sudo_client_v1, new_server, client_v1, normal_user):


### PR DESCRIPTION
This PR introduces support of cloud-init config generation for CephLCM cluster hosts.

### cephlcm-cloud-config CLI tool

This tool allows to generate copypastable cloud-init config for all tools, which provides support of cloud-init user-data host provision (eg. MAAS, OpenStack etc)

```
usage: cephlcm-cloud-config [-h] [-k [PUBLIC_KEY]] [-u USERNAME] [-g GROUP]
                            [-t TIMEOUT] [-d]
                            url token

Generate user data configuration for cloud-init on cephlcm cluster hosts.

positional arguments:
  url                   URL of CephLCM API.
  token                 Server token.

optional arguments:
  -h, --help            show this help message and exit
  -k [PUBLIC_KEY], --public-key [PUBLIC_KEY]
                        Path to the public key file. If nothing is provided,
                        then stdin will be used as a source.
  -u USERNAME, --username USERNAME
                        Username for Ansible to use. Default is 'ansible'.
  -g GROUP, --group GROUP
                        Group of Ansible user to use. Default is given
                        username.
  -t TIMEOUT, --timeout TIMEOUT
                        Timeout to access API in seconds. Default is 5.
  -d, --debug           Generate debugable cloud config.
```

Using this tool, it is possible to generate proper cloud configs for server sets. Example of current Vagrant-based enviornment config, generated by this tool:

```bash
$ cephlcm-cloud-config -k ~/.ssh/id_rsa.pub -u ansible -t 10 http://10.0.0.10:8000/v1/server/ 26758c32-3421-4f3d-9603-e4b5337e7ecc
```
```yaml
#cloud-config
bootcmd:
- [sh, -c, 'dmidecode | grep UUID | rev | cut -f1 -d'' '' | rev | tr ''[[:upper:]]'' ''[[:lower:]]'' | tr -d ''[[:space:]]'' > /tmp/__uuid__']
- [sh, -c, 'ip route get $(getent ahostsv4 ''10.0.0.10'' | head -n1 | cut -f1 -d'' '') | head -n1 | rev | cut -f2 -d'' '' | rev | tr -d ''[[:space:]]'' > /tmp/__ip__']
- [python2, -c, 'import json,urllib2;d={"username":''ansible'',"host":open(''/tmp/__ip__'').read(),"id":open(''/tmp/__uuid__'').read()};r=urllib2.Request(''http://10.0.0.10:8000/v1/server/'',json.dumps(d));r.add_header("Content-Type","application/json");r.add_header("Authorization",''26758c32-3421-4f3d-9603-e4b5337e7ecc'');print(urllib2.urlopen(r,timeout=10).read())']
- [rm, /tmp/__uuid__, /tmp/__ip__]
users:
- groups: [sudo, ansible]
  name: ansible
  shell: /bin/bash
  ssh-authorized-keys: [ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDDUz3JNMsSfA80Uko7sbilZ1T4OZ+QCxyqIeLJWbZ//0TsSJapipC5z/K+eTpCABLTPM5hGYxMIzTYeeBPeNUmuJHTQ/TYJhLuGLYPwC4qazC6D6TK1UuqsZ+F6uaC9K6ip5XcqhRc8YJr4NW03EBOj2U+QjgA8A7os4uQ8CeniD0FqzkF/fBdJ3VF4+6JunFbJpNSsFIA/fj75oCE2Zvv8MqVYL8CEWdN6dPtqgQFAxX2ljGPzDYkSgyGz8/hxss5cy/8/un42dBZpcOQNezwYo374C1nB+WMRMVrYNqxrClUrpydd41R5PkGZoNiGCIFZkJmiijm8/7r1qUzpk+v sarkhip@mera.ru]
  sudo: ['ALL=(ALL) NOPASSWD:ALL']
```

This output is ready to be copypasted into your cloud-init user data fields.

Some comments on the mess above:

1. New user (in example above, `ansbile`) will be created, add to sudoers. Also, public key will be injected into her `~/.ssh/authorized_keys`. Ansible will use this user (and complimentary private key) to access machine.

2. cloud-init has bizzare separation on `runcmd` and `bootcmd` sections. Each section defines a list of commands, which should be executed by cloud-init. `bootcmd` is executed as early as possible on **every** boot. `runcmd` is executed only **once**. So we have to use bootcmd with it's limitation: it is executed on early stages, so it is not possible to install packages. It is not possible to run `phone_home` command because, well, order of command execution is out of control of user-data script. So magic is happened there. I am going to explain every command:
    1. `dmidecode | grep UUID | rev | cut -f1 -d' ' | rev | tr '[[:upper:]]' '[[:lower:]]' | tr -d '[[:space:]]' > /tmp/__uuid__`

       This command extracts UUID of BIOS on local machine and save it into `/tmp/__uuid__` file. The trick of `rev | cut -f1 -d' ' | rev` is the same as `awk '{print $NF}'` but `awk` with its dollar after escaping obfuscates script a lot. Horrible I know, but at least `rev | rev` trick is more readable then parsing this `\\$$` crap.
    2. `getent ahostsv4 '10.0.0.10' | head -n1 | cut -f1 -d' '`

       It is safe to use `getent` since it comes with `libc-bin` package. This commandline just extracts IPv4 address of the host, it does not matter if it is a hostname of IP. If it is IP, it will be IP.
    3. `ip route get 10.0.0.10 | head -n1 | rev | cut -f2 -d' ' | rev | tr -d '[[:space:]]' > /tmp/__ip__`

       Funky trick to get IP address on the same network as will be used to access CephLCM API. If machine has multiple NICs, only appropriate NIC will be used. This command stores IP address to the `/tmp/__ip__` file.
    4. `python2 -c 'import json,urllib2;d={"username":'ansible',"host":open('/tmp/__ip__').read(),"id":open('/tmp/__uuid__').read()};r=urllib2.Request('http://10.0.0.10:8000/v1/server/',json.dumps(d));r.add_header("Content-Type","application/json");r.add_header("Authorization",'26758c32-3421-4f3d-9603-e4b5337e7ecc');print(urllib2.urlopen(r,timeout=10).read())'`

       Curl replacement. We cannot even assume that remote machine has curl (moreover, I am convinced that ops shall insist on curl absence in production). Basically, this is the inlined script:

```python
import json
import urllib2

data = {
    "username": "ansible",
    "host": open("/tmp/__ip__").read(),
    "id": open("/tmp/__uuid__").read()
}

request = urllib2.Request("http://10.0.0.10:8000/v1/auth/", json.dumps(data))
request.add_header("Content-Type", "application/json")
request.add_header("Authorization", "26758c32-3421-4f3d-9603-e4b5337e7ecc")

print(urllib2.urlopen(request, timeout=10).read())
```

That simple.



### Vagrant environment changes

1. `mon`, `osd0`, `osd1` and `osd2` hosts use generated cloud-init. This cloud-init config is created anytime `vagrant` command is executed
2. `mon`, `osd0`, `osd1` and `osd2` are trying to register themselves using `10.0.0.10:8000/v1/server` API endpoint. `10.0.0.10` is the IP of the default devbox



### cloud-init sidenotes

User-data is here: `/var/lib/cloud/seed/no-cloud/user-data`. To relaunch cloud-init do following:

```shell
$ sudo rm -r /var/lib/cloud/instances/*
$ sudo cloud-init -d init --local
$ sudo cloud-init -d init
$ sudo cloud-init -d modules
```

I hope Canonical folks will document this oneday. The stuff above is worth to be add to official documentation instead of ranting on amount of supported platforms.



### API changes

1. New config is add, `api.server_discovery_token`. This token will be used only for one API endpoint, `POST /v1/server/`. No real user or role is created, it is ephemeral token for 1 endpoint. To revoke it just modify configs and restart API service.