### PR TITLE
Reworked user data for cloud-init

### DIFF
--- a/cephlcmlib/cephlcmlib/client.py
+++ b/cephlcmlib/cephlcmlib/client.py
@@ -223,6 +223,9 @@ class V1Client(Client):
         return response
 
     def logout(self, **kwargs):
+        if not self._session.auth.token:
+            return {}
+
         url = self._make_url(self.AUTH_CLASS.AUTH_URL)
 
         try:

--- a/cephlcmlib/cephlcmlib/cloud_config.py
+++ b/cephlcmlib/cephlcmlib/cloud_config.py
@@ -69,6 +69,11 @@ print("Server discovery completed.")
 """.strip()
 """Python program to use instead of Curl."""
 
+PACKAGES = (
+    "python",
+)
+"""A list of packages to install with cloud-init."""
+
 
 def generate_cloud_config(url, server_discovery_token, public_key, username,
                           timeout=REQUEST_TIMEOUT, debug=False,
@@ -81,6 +86,7 @@ def generate_cloud_config(url, server_discovery_token, public_key, username,
 
     document = {
         "users": get_users(username, public_key),
+        "packages": PACKAGES,
         "bootcmd": get_bootcmd(url, server_discovery_token, username, timeout,
                                debug)
     }

--- a/cephlcmlib/cephlcmlib/cloud_config.py
+++ b/cephlcmlib/cephlcmlib/cloud_config.py
@@ -7,6 +7,8 @@ from __future__ import unicode_literals
 
 import base64
 import functools
+import gzip
+import io
 
 import six
 import six.moves
@@ -19,6 +21,15 @@ IP_FILENAME = "/tmp/__ip__"
 UUID_FILENAME = "/tmp/__uuid__"
 """Temporary filename to store machine UUID."""
 
+PYTHON_MARKER_FILENAME = "/tmp/__server_discovery__"
+"""Marker filename for Pythons.
+
+Basically, we do not know if python2 or python3 were installed therefore
+we have to try both. To avoid 2 requests for server, we are going to
+use marker file. If one python succeed to run, then such file has to be
+created. It means that next python won't continue to work.
+"""
+
 DEFAULT_USER = "ansible"
 """Default user for Ansible."""
 
@@ -26,12 +37,35 @@ REQUEST_TIMEOUT = 5  # seconds
 """How long to wait for response from API."""
 
 PYTHON_PROG = """
-import json,urllib2
-d={{"username":{username!r},"host":open({ip_filename!r}).read(),"id":open({uuid_filename!r}).read()}}
-r=urllib2.Request({url!r},json.dumps(d))
-r.add_header("Content-Type","application/json")
-r.add_header("Authorization",{token!r})
-print(urllib2.urlopen(r,timeout={timeout}).read())
+from __future__ import print_function
+
+import json
+import os.path
+import sys
+
+try:
+    import urllib.request as urllib2
+except ImportError:
+    import urllib2
+
+if os.path.exists({marker_filename!r}):
+    sys.exit(0)
+
+open({marker_filename!r}, "w").close()
+
+data = {{
+    "username": {username!r},
+    "host": open({ip_filename!r}).read().strip(),
+    "id": open({uuid_filename!r}).read().strip()
+}}
+
+request = urllib2.Request({url!r}, json.dumps(data).encode("utf-8"))
+request.add_header("Content-Type", "application/json")
+request.add_header("Authorization", {token!r})
+request.add_header("User-Agent", "cloud-init server discovery")
+
+urllib2.urlopen(request, timeout={timeout}).read()
+print("Server discovery completed.")
 """.strip()
 """Python program to use instead of Curl."""
 
@@ -83,19 +117,23 @@ def get_users(username, public_key):
 
 
 def get_bootcmd(url, server_discovery_token, username, timeout, debug):
-    bootcmd = [
+    command = [
         get_command_header(),
         get_command_debug(url, server_discovery_token),
+        get_command_clean(),
         get_command_uuid(debug),
-        get_command_ip(url, debug),
-        get_command_notify(url, server_discovery_token, username, timeout),
+        get_command_ip(url, debug)
+    ]
+    command += get_commands_notify(url, server_discovery_token, username,
+                                   timeout)
+    command += [
         get_command_clean(),
         get_command_footer()
     ]
     if not debug:
-        bootcmd = bootcmd[2:-1]
+        command = command[2:-1]
 
-    return bootcmd
+    return command
 
 
 def get_command_header():
@@ -129,22 +167,30 @@ def get_command_ip(url, debug):
     )
 
 
-def get_command_notify(url, server_discovery_token, username, timeout):
+def get_commands_notify(url, server_discovery_token, username, timeout):
     program = PYTHON_PROG.format(
         username=username,
         ip_filename=IP_FILENAME,
         uuid_filename=UUID_FILENAME,
+        marker_filename=PYTHON_MARKER_FILENAME,
         url=url,
         token=server_discovery_token,
         timeout=timeout
     )
-    program = ";".join(program.split("\n"))
+    program = gzip_text(program)
+    program = base64.b64encode(program)
+    program = program.decode("utf-8")
 
-    return ["python2", "-c", program]
+    return [
+        ["sh", "-xc",
+         "echo {0!r} | base64 -d | gzip -d | python2 -".format(program)],
+        ["sh", "-xc",
+         "echo {0!r} | base64 -d | gzip -d | python3 -".format(program)],
+    ]
 
 
 def get_command_clean():
-    return ["rm", UUID_FILENAME, IP_FILENAME]
+    return ["rm", "-f", UUID_FILENAME, IP_FILENAME, PYTHON_MARKER_FILENAME]
 
 
 def get_command_footer():
@@ -167,3 +213,16 @@ def get_hostname(hostname):
     parsed = parsed.netloc.split(":", 1)[0]
 
     return parsed
+
+
+def gzip_text(text):
+    text = text.encode("utf-8")
+
+    if hasattr(gzip, "compress"):  # python 3.2+
+        return gzip.compress(text, compresslevel=9)
+
+    fileobj = io.BytesIO()
+    with gzip.GzipFile(mode="wb", fileobj=fileobj, compresslevel=9) as gzfp:
+        gzfp.write(text)
+
+    return fileobj.getvalue()


### PR DESCRIPTION
After testing cephlcm with MAAS it was discovered several truths:

1. Current version of cloud-init swears on adding user to self-named default group so user is add only to `sudo` group
2. Xenial cloud-init is mindblowing about Python it is used. Basically, you do not have `/usr/bin/python` or any `python` in `$PATH`. Yes, it installs `python3.5` package and does not care. We have to install `python` manually
3. We have to run python program with both `python2` and `python3` trying to find out proper python to use. Thankfully, it runs all commands in `bootcmd` section so we are doing following trick.

Program is reworked to support both python2 and python3. It looks like this:

```python
from __future__ import print_function

import json
import os.path
import sys

try:
    import urllib.request as urllib2
except ImportError:
    import urllib2

if os.path.exists('/tmp/__server_discovery__'):
    sys.exit(0)

open('/tmp/__server_discovery__', "w").close()

data = {
    "username": 'ansible',
    "host": open('/tmp/__ip__').read().strip(),
    "id": open('/tmp/__uuid__').read().strip()
}

request = urllib2.Request('http://10.10.0.5:9999/v1/server/', json.dumps(data).encode("utf-8"))
request.add_header("Content-Type", "application/json")
request.add_header("Authorization", '26758c32-3421-4f3d-9603-e4b5337e7ecc')
request.add_header("User-Agent", "cloud-init server discovery")

urllib2.urlopen(request, timeout=5).read()
print("Server discovery completed.")
```

We run it against both `python2` and `python3` sending it to stdin of both interpreters. To allow cloud-config to transmit this program, we gzip it and base64 after. So basically, we are working in the same way as, let's say, MAAS does with user data. User data now looks like this

```yaml
#cloud-config
bootcmd:
- [rm, -f, /tmp/__uuid__, /tmp/__ip__, /tmp/__server_discovery__]
- [sh, -xc, 'dmidecode | grep UUID | rev | cut -f1 -d'' '' | rev | tr ''[[:upper:]]'' ''[[:lower:]]'' | tr -d ''[[:space:]]'' > /tmp/__uuid__']
- [sh, -xc, 'ip route get $(getent ahostsv4 ''10.10.0.5'' | head -n1 | cut -f1 -d'' '') | head -n1 | rev | cut -f2 -d'' '' | rev | tr -d ''[[:space:]]'' > /tmp/__ip__']
- [sh, -xc, echo 'H4sIAL0n7VcC/31STY+bMBC9+1dYvgBSMAkkm91IOayqHnrtxxk5eCiuALv2eLtp1f/egUClrqJalrAfb97MG0/r7cDruo0YPdQ1N4OzHrnzZkRCxwaNHRlb4G+BLsvZBukUdus1XANj6K8nxmktYPR9by7Sw/cIAbkKC1IyeG3AIf8w8957b/2dwJISt2siCa8mYEiTAgdX1HUA/wK+1iY0lg7Xuk6ymwaVMpEx3WaMWQfj/2I2XPwQmWx6GyAlvlao+Jn/mpVEpIhRDSBOPFFjMJceks3tV2cDEvyPvnFTFeRX6TSTAb1xabbwjX7LjtHoO3z2m7G1Y+e1E/LjDUmTDtGdimK3lbS38nB6olW87IqbuYIcTc8kdRxcSCc7mYSxsRpSEbHNH0WWrfpSaV13lB18Kt7ZEWHE/PPVgaC2KOd606hpAIpJUdwPe47YWW9+zkSKS8qH4+Gxqcq82pe7fN9WOn962FY57C+HqjrCEZomua/1hTzkz1+piqkAepOoczMamq7ZG//7cFQLWztD37mti+CGoxnARjwf1s6yeZxT8emNCm/s4HpA0FJkfwCJB4iHCgMAAA==' | base64 -d | gzip -d | python2 -]
- [sh, -xc, echo 'H4sIAL0n7VcC/31STY+bMBC9+1dYvgBSMAkkm91IOayqHnrtxxk5eCiuALv2eLtp1f/egUClrqJalrAfb97MG0/r7cDruo0YPdQ1N4OzHrnzZkRCxwaNHRlb4G+BLsvZBukUdus1XANj6K8nxmktYPR9by7Sw/cIAbkKC1IyeG3AIf8w8957b/2dwJISt2siCa8mYEiTAgdX1HUA/wK+1iY0lg7Xuk6ymwaVMpEx3WaMWQfj/2I2XPwQmWx6GyAlvlao+Jn/mpVEpIhRDSBOPFFjMJceks3tV2cDEvyPvnFTFeRX6TSTAb1xabbwjX7LjtHoO3z2m7G1Y+e1E/LjDUmTDtGdimK3lbS38nB6olW87IqbuYIcTc8kdRxcSCc7mYSxsRpSEbHNH0WWrfpSaV13lB18Kt7ZEWHE/PPVgaC2KOd606hpAIpJUdwPe47YWW9+zkSKS8qH4+Gxqcq82pe7fN9WOn962FY57C+HqjrCEZomua/1hTzkz1+piqkAepOoczMamq7ZG//7cFQLWztD37mti+CGoxnARjwf1s6yeZxT8emNCm/s4HpA0FJkfwCJB4iHCgMAAA==' | base64 -d | gzip -d | python3 -]
- [rm, -f, /tmp/__uuid__, /tmp/__ip__, /tmp/__server_discovery__]
packages: [python]
users:
- groups: [sudo]
  name: ansible
  shell: /bin/bash
  ssh-authorized-keys: [ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDDUz3JNMsSfA80Uko7sbilZ1T4OZ+QCxyqIeLJWbZ//0TsSJapipC5z/K+eTpCABLTPM5hGYxMIzTYeeBPeNUmuJHTQ/TYJhLuGLYPwC4qazC6D6TK1UuqsZ+F6uaC9K6ip5XcqhRc8YJr4NW03EBOj2U+QjgA8A7os4uQ8CeniD0FqzkF/fBdJ3VF4+6JunFbJpNSsFIA/fj75oCE2Zvv8MqVYL8CEWdN6dPtqgQFAxX2ljGPzDYkSgyGz8/hxss5cy/8/un42dBZpcOQNezwYo374C1nB+WMRMVrYNqxrClUrpydd41R5PkGZoNiGCIFZkJmiijm8/7r1qUzpk+v sarkhip@mera.ru]
  sudo: ['ALL=(ALL) NOPASSWD:ALL']
```

So, send blob it to stdin with `echo`, decode with base64 (`base64 -d`), decode with gzip (`gzip -d`) and feed it to python (`python3 -`). Horrible but there are no any guarantees on cloud init python interpreter.