### PR TITLE
Gathering of custom Ceph facts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ make_output_directory:
 # -----------------------------------------------------------------------------
 
 build_ui: clean_ui npm_install
-	cd "$(ROOT_DIR)/ui" && ./node_modules/gulp/bin/gulp.js && rm -rf build/tmp
+	cd "$(ROOT_DIR)/ui" && npm run build
 
 npm_install:
 	cd "$(ROOT_DIR)/ui" && npm install

--- a/backend/common/cephlcm_common/playbook_plugin.py
+++ b/backend/common/cephlcm_common/playbook_plugin.py
@@ -172,6 +172,9 @@ class Ansible(Base, metaclass=abc.ABCMeta):
 
     ANSIBLE_CMD = shutil.which("ansible")
     MODULE = None
+    BECOME = True
+    ONE_LINE = True
+    EXTRA_VARS = {}
 
     @abc.abstractmethod
     def compose_command(self, task):
@@ -183,6 +186,14 @@ class Ansible(Base, metaclass=abc.ABCMeta):
         cmdline = [self.ANSIBLE_CMD]
         cmdline.extend(["--inventory-file", DYNAMIC_INVENTORY_PATH])
         cmdline.extend(["--module-name", self.MODULE])
+
+        if self.ONE_LINE:
+            cmdline.append("--one-line")
+        if self.BECOME:
+            cmdline.append("--become")
+        for key, value in sorted(self.EXTRA_VARS.items()):
+            cmdline.extend(
+                ["--extra-vars", shlex.quote("{0}={1}".format(key, value))])
 
         extra = self.get_extra_vars(task)
         if extra:
@@ -198,6 +209,8 @@ class Playbook(Base, metaclass=abc.ABCMeta):
     PROCESS_STDOUT = subprocess.DEVNULL
     PROCESS_STDERR = subprocess.DEVNULL
     PROCESS_STDIN = subprocess.DEVNULL
+    BECOME = False
+    EXTRA_VARS = {}
 
     @property
     def playbook_config(self):
@@ -223,6 +236,12 @@ class Playbook(Base, metaclass=abc.ABCMeta):
 
         cmdline = [self.ANSIBLE_CMD]
         cmdline.extend(["--inventory-file", DYNAMIC_INVENTORY_PATH])
+
+        if self.BECOME:
+            cmdline.append("--become")
+        for key, value in sorted(self.EXTRA_VARS.items()):
+            cmdline.extend(
+                ["--extra-vars", shlex.quote("{0}={1}".format(key, value))])
 
         extra = self.get_extra_vars(task)
         if extra:

--- a/plugins/playbook/deploy_cluster/MANIFEST.in
+++ b/plugins/playbook/deploy_cluster/MANIFEST.in
@@ -1,2 +1,3 @@
 include cephlcm_deploy_cluster/config.yaml
 include cephlcm_deploy_cluster/playbook.yaml
+graft cephlcm_deploy_cluster/templates

--- a/plugins/playbook/deploy_cluster/cephlcm_deploy_cluster/playbook.yaml
+++ b/plugins/playbook/deploy_cluster/cephlcm_deploy_cluster/playbook.yaml
@@ -49,3 +49,22 @@
   become: True
   roles:
   - ceph-iscsi-gw
+
+# Add custom local facts
+# Can be obtained by ansible_local.ceph_{{ cluster }} section in facts
+- hosts: all
+  become: true
+  tasks:
+    - name: Ensure ansible local facts directory is created
+      file:
+        path: /etc/ansible/facts.d
+        state: directory
+        recurse: yes
+
+    - name: Create local facts to gather ceph clusters
+      template:
+        src: "{{ ceph_facts_template }}"
+        dest: "/etc/ansible/facts.d/ceph_{{ cluster }}.fact"
+        owner: "{{ ansible_user }}"
+        group: "{{ ansible_user }}"
+        mode: 0770

--- a/plugins/playbook/deploy_cluster/cephlcm_deploy_cluster/plugin.py
+++ b/plugins/playbook/deploy_cluster/cephlcm_deploy_cluster/plugin.py
@@ -2,6 +2,8 @@
 """Playbook plugin to deploy Ceph cluster."""
 
 
+import pkg_resources
+
 from cephlcm_common import log
 from cephlcm_common import playbook_plugin
 
@@ -93,6 +95,8 @@ class DeployCluster(playbook_plugin.CephAnsiblePlaybook):
 
         result["journal_collocation"] = self.config["journal"]["collocation"]
         result["journal_size"] = self.config["journal"]["size"]
+        result["ceph_facts_template"] = pkg_resources.resource_filename(
+            "cephlcm_deploy_cluster", "templates/ceph_facts_module.py.j2")
 
         return result
 

--- a/plugins/playbook/deploy_cluster/cephlcm_deploy_cluster/templates/ceph_facts_module.py.j2
+++ b/plugins/playbook/deploy_cluster/cephlcm_deploy_cluster/templates/ceph_facts_module.py.j2
@@ -1,0 +1,140 @@
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+# vim: set ft=python:
+"""
+This module should be placed in /etc/ansible/facts.d/ceph.facts on remote
+host.
+
+This should be Python 2 script. And Jinja2 template, with following context:
+
+{
+    "cluster": "cluster"
+}
+"""
+
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import functools
+import json
+import logging
+import os
+import re
+import subprocess
+import sys
+
+
+CLUSTER_NAME = "{{ cluster }}"
+"""Name of the cluster."""
+
+CEPH_DISK_LIST_LINE = re.compile(
+    r"^\s*(?P<data_device>\S+)\s+ceph\sdata,"
+    r"\s*\w+,"
+    r"\s*cluster\s*(?P<cluster>\w+),"
+    r"\s*(?P<osd_name>\S+),"
+    r"\s*journal\s*(?P<journal_device>\S+)\s*$",
+    re.UNICODE
+)
+
+LOG = logging.getLogger(__name__)
+"""Logger."""
+
+
+if sys.version_info >= (3,):
+    unicode = lambda item: item.decode("utf-8")
+
+
+def handle_exceptions(func):
+    @functools.wraps(func)
+    def decorator(*args, **kwargs):
+        try:
+            func(*args, **kwargs)
+        except Exception as exc:
+            LOG.exception("Cannot collect facts: %s", exc)
+            print_json(
+                {"osd_tree": {}, "osd_partitions": {}, "error": unicode(exc)}
+            )
+            return os.EX_SOFTWARE
+        return os.EX_OK
+
+    return decorator
+
+
+@handle_exceptions
+def main():
+    response = {
+        "osd_tree": get_osd_tree(),
+        "osd_partitions": get_osd_partitions(),
+        "error": None
+    }
+    print_json(response)
+
+
+def get_osd_tree():
+    output = get_json_output(
+        ["ceph", "--cluster", CLUSTER_NAME, "osd", "tree", "-f", "json"],
+        wait_stderr=False
+    )
+    output = {item["id"]: item for item in output["nodes"]}
+    osd_tree = {}
+
+    for item in output.values():
+        if item["type"] == "host":
+            osd_tree[item["name"]] = [output[_id] for _id in item["children"]]
+
+    return osd_tree
+
+
+def get_osd_partitions():
+    output = get_plain_output(["ceph-disk", "list"])
+    output = [line.strip() for line in output.split("\n") if line.strip()]
+    partitions = {}
+
+    for line in output:
+        matcher = CEPH_DISK_LIST_LINE.match(line)
+        if not matcher:
+            continue
+
+        matcher = matcher.groupdict()
+        partitions.setdefault(matcher["cluster"], {})[matcher["osd_name"]] = {
+            "journal": matcher["journal_device"],
+            "data": matcher["data_device"]
+        }
+
+    return partitions
+
+
+def get_json_output(command, wait_stderr=False):
+    output = get_plain_output(command, wait_stderr).strip()
+    if not output:
+        logging.error("Output of %s is empty", command)
+        raise ValueError("Output of {0} is empty".format(command))
+
+    return json.loads(output)
+
+
+def get_plain_output(command, wait_stderr=False):
+    with open(os.devnull) as devnull:
+        process = subprocess.Popen(
+            command,
+            stderr=subprocess.PIPE, stdout=subprocess.PIPE, stdin=devnull)
+        stdout, stderr = process.communicate()
+
+    logging.debug("Stdout of %s: %s", command, stdout)
+    logging.warning("Stderr of %s: %s", command, stderr)
+
+    if process.returncode != os.EX_OK:
+        logging.error("Command %s has been finished with exit code %d",
+                      command, process.returncode)
+
+    return stderr if wait_stderr else stdout
+
+
+def print_json(data):
+    print(json.dumps(data, indent=4, sort_keys=True))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/playbook/deploy_cluster/setup.py
+++ b/plugins/playbook/deploy_cluster/setup.py
@@ -24,7 +24,8 @@ setuptools.setup(
     package_data={
         "cephlcm_deploy_cluster": [
             "config.yaml",
-            "playbook.yaml"
+            "playbook.yaml",
+            "templates/*"
         ]
     },
     install_requires=[

--- a/plugins/playbook/purge_cluster/cephlcm_purge_cluster/playbook.yaml
+++ b/plugins/playbook/purge_cluster/cephlcm_purge_cluster/playbook.yaml
@@ -37,62 +37,19 @@
         state: absent
 
   tasks:
-    - name: See if ceph-disk-created data partitions are present
-      shell: 'ls /dev/disk/by-partlabel | grep -q "ceph.*.data"'
-      failed_when: false
-      register: ceph_data_partlabels
-
-    - name: See if ceph-disk-created journal partitions are present
-      shell: 'ls /dev/disk/by-partlabel | grep -q "ceph.*.journal"'
-      failed_when: false
-      register: ceph_journal_partlabels
-
-    - name: Get Ceph journal partitions
-      shell: |
-        blkid | awk '/ceph journal/ { sub (":", "", $1); print $1 }'
-      when:
-        - ceph_journal_partlabels.rc == 0
-      failed_when: false
-      register: ceph_journal_partition_to_erase_path
-
-    - name: Get OSD data mount points
-      shell: "(grep /var/lib/ceph/osd /proc/mounts || echo -n) | awk '{ print $2  }'"
-      register: mounted_osd
-      changed_when: false
+    - set_fact: cluster_data="{{ ansible_local['ceph_%s'|format(cluster)] }}"
+    - set_fact: osd_data="{{ cluster_data.osd_tree[ansible_hostname] }}"
 
     - name: drop all cache
       shell: "sync && sleep 1 && echo 3 > /proc/sys/vm/drop_caches"
 
-    - name: umount osd data partition
-      shell: umount "{{ item }}"
-      with_items:
-        - "{{ mounted_osd.stdout_lines }}"
+    - name: Deactivate OSDs
+      command: ceph-disk deactivate --cluster "{{ cluster }}" --deactivate-by-id "{{ item.id }}" --mark-out
+      with_items: "{{ osd_data }}"
 
-    - name: remove osd mountpoint tree
-      file:
-        path: /var/lib/ceph/osd/
-        state: absent
-      register: remove_osd_mountpoints
-      ignore_errors: true
-
-    - name: See if ceph-disk is installed
-      shell: "which ceph-disk"
-      failed_when: false
-      register: ceph_disk_present
-
-    - name: Get Ceph disks
-      shell: |
-        ceph-disk list 2>&1 | awk '$2 == "ceph" {print $1}' | xargs -n 1 -r lsblk -no pkname | sort -u | sed 's?^?/dev/?'
-      register: ceph_disks_to_zap
-      when:
-        ceph_disk_present.rc == 0
-
-    - name: Zap OSD disks
-      command: ceph-disk zap "{{ item }}"
-      with_items:
-        - "{{ ceph_disks_to_zap.stdout_lines }}"
-      when:
-        ceph_disk_present.rc == 0 and ceph_disks_to_zap is defined
+    - name: Destroy OSDs
+      command: ceph-disk destroy --cluster "{{ cluster }}" --destroy-by-id "{{ item.id }}" --zap
+      with_items: "{{ osd_data }}"
 
     - name: is reboot needed
       local_action: shell echo requesting reboot

--- a/plugins/playbook/purge_cluster/cephlcm_purge_cluster/plugin.py
+++ b/plugins/playbook/purge_cluster/cephlcm_purge_cluster/plugin.py
@@ -46,7 +46,7 @@ class PurgeCluster(playbook_plugin.CephAnsiblePlaybook):
         return global_vars, inventory
 
     def make_global_vars(self, cluster, servers):
-        return {}
+        return {"cluster": cluster.name}
 
     def make_inventory(self, cluster, servers):
         groups = self.get_inventory_groups(cluster, servers)

--- a/tests/plugins/test_server_discovery.py
+++ b/tests/plugins/test_server_discovery.py
@@ -65,7 +65,7 @@ def test_compose_command(new_task, plugin):
     opts, args = getopt.getopt(
         cmdline[1:],
         ":m:i:t:",
-        ["inventory-file=", "module-name=", "tree="]
+        ["inventory-file=", "module-name=", "tree=", "become=", "one-line="]
     )
     opts = dict(opts)
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -26,7 +26,8 @@
     "tsc": "tsc",
     "tsc:w": "tsc -w",
     "typings": "typings",
-    "webdriver:update": "webdriver-manager update"
+    "webdriver:update": "webdriver-manager update",
+    "build": "gulp"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
This PR introduces custom Ceph facts. Fact collector is installed on each node and you may obtain results of its work from `ansible_local` fact. Please be noticed that fact is gathered if `setup` module is executed with `become: True`.

It returns results like:

```json
{
        "osd_partitions": {
            "ceph": {
                "osd.2": {
                    "data": "/dev/vdb1", 
                    "journal": "/dev/vdb2"
                }
            }
        }, 
        "osd_tree": {
            "light-burro": [
                {
                    "crush_weight": 0.019394, 
                    "depth": 2, 
                    "exists": 1, 
                    "id": 2, 
                    "name": "osd.2", 
                    "primary_affinity": 1.0, 
                    "reweight": 1.0, 
                    "status": "up", 
                    "type": "osd", 
                    "type_id": 0
                }
            ], 
            "subtle-pig": [
                {
                    "crush_weight": 0.019394, 
                    "depth": 2, 
                    "exists": 1, 
                    "id": 1, 
                    "name": "osd.1", 
                    "primary_affinity": 1.0, 
                    "reweight": 1.0, 
                    "status": "up", 
                    "type": "osd", 
                    "type_id": 0
                }
            ], 
            "valued-sheep": [
                {
                    "crush_weight": 0.019394, 
                    "depth": 2, 
                    "exists": 1, 
                    "id": 0, 
                    "name": "osd.0", 
                    "primary_affinity": 1.0, 
                    "reweight": 1.0, 
                    "status": "up", 
                    "type": "osd", 
                    "type_id": 0
                }
            ]
        }
    }
```

Such result may be found in `ansible_local`, `ceph_{{ cluster }}` section.