### PR TITLE
Implement task limit in controller

### DIFF
--- a/backend/common/cephlcm_common/exceptions.py
+++ b/backend/common/cephlcm_common/exceptions.py
@@ -47,6 +47,10 @@ class CannotFailTask(CephLCMError):
     """Exception raised if it is impossible to fail such task."""
 
 
+class CannotBounceTaskError(CephLCMError):
+    """Exception raised if it is impossible to bounce task."""
+
+
 class CannotSetExecutorError(CephLCMError):
     """Exception raised if it is impossible to set executor data."""
 

--- a/backend/common/cephlcm_common/models/task.py
+++ b/backend/common/cephlcm_common/models/task.py
@@ -421,13 +421,13 @@ class Task(generic.Base):
                 document = find_method(query, sort=sortby)
 
                 if stop_condition.is_set():
-                    raise StopIteration
+                    raise StopIteration()
                 if document:
                     yield cls.make_task(document)
-                watch_again = timeutils.current_unix_timestamp()
-                if stop_condition.is_set():
-                    raise StopIteration
+                elif exit_on_empty:
+                    raise StopIteration()
 
+                watch_again = timeutils.current_unix_timestamp()
                 if fetched_at != watch_again:
                     stop_condition.wait(1)
         except pymongo.errors.OperationFailure as exc:

--- a/backend/controller/cephlcm_controller/mainloop.py
+++ b/backend/controller/cephlcm_controller/mainloop.py
@@ -88,9 +88,6 @@ def possible_to_process(tsk):
 
 def process_task(tsk):
     LOG.info("Start to process task %s", tsk._id)
-
-    tsk.start()
-
     TASK_POOL.submit(tsk)
 
 

--- a/backend/controller/cephlcm_controller/mainloop.py
+++ b/backend/controller/cephlcm_controller/mainloop.py
@@ -41,6 +41,11 @@ def main():
                 "Fetched task %s (execution_id=%s, task_type=%s)",
                 tsk._id, tsk.execution_id, tsk.task_type
             )
+            try:
+                tsk.bounce()
+            except Exception as exc:
+                LOG.warning("Cannot bounce task %s. Skip. %s", tsk._id, exc)
+                continue
 
             if not possible_to_process(tsk):
                 LOG.info("Task %s is temporarily skipped.", tsk._id)

--- a/backend/controller/cephlcm_controller/taskpool.py
+++ b/backend/controller/cephlcm_controller/taskpool.py
@@ -7,6 +7,7 @@ import concurrent.futures
 import multiprocessing
 import os
 import platform
+import queue
 import threading
 import time
 
@@ -30,6 +31,7 @@ class TaskPool:
 
     def __init__(self, capacity=0):
         capacity = capacity or multiprocessing.cpu_count() * 2
+        self.task_queue = queue.Queue(capacity)
 
         self.pool = concurrent.futures.ThreadPoolExecutor(capacity)
         self.data = {}
@@ -64,6 +66,17 @@ class TaskPool:
                     "Removed finished task %s. Current active "
                     "tasks %d", tsk, len(self.data)
                 )
+
+            self.task_queue.get_nowait()
+            self.task_queue.task_done()
+
+        self.task_queue.put(True, block=True)
+        try:
+            tsk.start()
+        except:
+            self.task_queue.get_nowait()
+            self.task_queue.task_done()
+            raise
 
         future = self.pool.submit(self.execute, tsk, stop_event)
         future.add_done_callback(done_callback)
@@ -118,12 +131,8 @@ class TaskPool:
                     ts.stop_event.set()
 
         LOG.debug("Waiting for all tasks to be cancelled.")
-        while True:
-            if self.data:
-                time.sleep(0.2)
-            else:
-                LOG.debug("All tasks were stopped.")
-                return
+        self.task_queue.join()
+        LOG.debug("All tasks were stopped.")
 
     def cancel(self, task_id):
         if self.global_stop_event.is_set():

--- a/backend/controller/cephlcm_controller/taskpool.py
+++ b/backend/controller/cephlcm_controller/taskpool.py
@@ -73,7 +73,7 @@ class TaskPool:
         self.task_queue.put(True, block=True)
         try:
             tsk.start()
-        except:
+        except Exception:
             self.task_queue.get_nowait()
             self.task_queue.task_done()
             raise

--- a/tests/controller/test_mainloop.py
+++ b/tests/controller/test_mainloop.py
@@ -53,12 +53,12 @@ def new_task(public_playbook_name, configured_new_pcmodel, new_execution):
 
 
 def test_shutdown_callback(main_thread):
-    time.sleep(0.5)
+    time.sleep(1.5)
 
     assert main_thread.is_alive()
     mainloop.shutdown_callback()
 
-    time.sleep(0.5)
+    time.sleep(1.5)
     assert not main_thread.is_alive()
 
 

--- a/tests/controller/test_mainloop.py
+++ b/tests/controller/test_mainloop.py
@@ -53,12 +53,12 @@ def new_task(public_playbook_name, configured_new_pcmodel, new_execution):
 
 
 def test_shutdown_callback(main_thread):
-    time.sleep(1.5)
+    time.sleep(.5)
 
     assert main_thread.is_alive()
     mainloop.shutdown_callback()
 
-    time.sleep(1.5)
+    time.sleep(.5)
     assert not main_thread.is_alive()
 
 

--- a/tests/controller/test_taskpool.py
+++ b/tests/controller/test_taskpool.py
@@ -26,7 +26,6 @@ def create_task():
 
     tsk = task.ServerDiscoveryTask(server_id, host, username, initiator_id)
     tsk = tsk.create()
-    tsk = tsk.start()
 
     return tsk
 
@@ -49,7 +48,7 @@ def mocked_plugin():
 
 @pytest.yield_fixture
 def tpool():
-    tp = taskpool.TaskPool(1)
+    tp = taskpool.TaskPool(50)
     yield tp
     tp.stop()
 


### PR DESCRIPTION
Right now, controller consumes as much tasks as possible and puts them into executor. Executor limits amount of tasks under execution but unfortunately, its queue is unlimit. This PR bring artifical limit in task pool. Controller won't consume tasks if all workers are occupied.