### PR TITLE
Execution logfiles

### DIFF
--- a/backend/api/cephlcm_api/views/generic.py
+++ b/backend/api/cephlcm_api/views/generic.py
@@ -4,6 +4,7 @@
 
 import posixpath
 
+import flask
 import flask.json
 import flask.views
 import werkzeug.exceptions
@@ -11,6 +12,11 @@ import werkzeug.exceptions
 from cephlcm_api import exceptions
 from cephlcm_api import pagination
 from cephlcm_common import log
+
+try:
+    import gridfs.grid_file as gridfile
+except ImportError:
+    gridfile = None
 
 
 LOG = log.getLogger(__name__)
@@ -55,6 +61,10 @@ class View(flask.views.MethodView):
         """Returns a dictionary with URL Query parameters."""
 
         return flask.request.args
+
+    @property
+    def request_headers(self):
+        return flask.request.headers
 
     @property
     def initiator_id(self):
@@ -285,3 +295,42 @@ def make_endpoint(*endpoint):
         url += "/"
 
     return url
+
+
+def fs_response(fileobj, download, mimetype=None, filename=None):
+    if gridfile is not None and isinstance(fileobj, gridfile.GridOut):
+        return gridfs_response(fileobj, download)
+
+    send_file_kwargs = {}
+    if mimetype is not None:
+        send_file_kwargs["mimetype"] = mimetype
+    if download:
+        send_file_kwargs["as_attachment"] = True
+        if filename is not None:
+            send_file_kwargs["attachment_filename"] = filename
+
+    return flask.send_file(fileobj, **send_file_kwargs)
+
+
+def gridfs_response(fileobj, download):
+    data = fileobj_generator(fileobj)
+    headers = {}
+
+    if download:
+        headers = {
+            "Content-Disposition": "attachment; filename=\"{0}\"".format(
+                fileobj.filename
+            )
+        }
+
+    response = flask.Response(data, mimetype=fileobj.content_type,
+                              headers=headers)
+    response.set_etag(fileobj.md5)
+
+    return response
+
+
+def fileobj_generator(fileobj):
+    with fileobj:
+        for chunk in fileobj:
+            yield chunk

--- a/backend/api/cephlcm_api/views/generic.py
+++ b/backend/api/cephlcm_api/views/generic.py
@@ -82,6 +82,9 @@ class View(flask.views.MethodView):
     def dispatch_request(self, *args, **kwargs):
         response = super().dispatch_request(*args, **kwargs)
 
+        if isinstance(response, flask.Response):
+            return response
+
         try:
             response = self.prepare_response(response)
         except Exception as exc:

--- a/backend/api/cephlcm_api/views/v1/__init__.py
+++ b/backend/api/cephlcm_api/views/v1/__init__.py
@@ -25,6 +25,7 @@ BLUEPRINT = flask.Blueprint(BLUEPRINT_NAME, __name__)
 
 auth.AuthView.register_to(BLUEPRINT)
 cluster.ClusterView.register_to(BLUEPRINT)
+execution.ExecutionStepsLog.register_to(BLUEPRINT)
 execution.ExecutionStepsView.register_to(BLUEPRINT)
 execution.ExecutionView.register_to(BLUEPRINT)
 info.InfoView.register_to(BLUEPRINT)

--- a/backend/api/cephlcm_api/views/v1/execution.py
+++ b/backend/api/cephlcm_api/views/v1/execution.py
@@ -215,4 +215,4 @@ class ExecutionStepsLog(generic.View):
         if not logfile:
             raise http_exceptions.NotFound()
 
-        return flask.send_file(logfile, mimetype="text/plain")
+        return flask.Response(logfile, mimetype="text/plain")

--- a/backend/api/cephlcm_api/views/v1/execution.py
+++ b/backend/api/cephlcm_api/views/v1/execution.py
@@ -184,3 +184,35 @@ class ExecutionStepsView(generic.CRUDView):
         return execution_step.ExecutionStep.list_models(
             str(item_id), self.pagination
         )
+
+
+class ExecutionStepsLog(generic.View):
+
+    NAME = "execution_step_log"
+
+    decorators = [
+        auth.require_authorization("api", "view_execution"),
+        auth.require_authorization("api", "view_execution_steps"),
+        auth.require_authentication
+    ]
+
+    @classmethod
+    def register_to(cls, application):
+        main_endpoint = generic.make_endpoint(
+            ExecutionView.ENDPOINT,
+            "<{0}:item_id>".format(ExecutionView.PARAMETER_TYPE),
+            "log"
+        )
+
+        application.add_url_rule(
+            main_endpoint,
+            view_func=cls.as_view(cls.NAME), methods=["GET"]
+        )
+
+    @validators.with_model(execution.ExecutionModel)
+    def get(self, item_id, item):
+        logfile = item.logfile
+        if not logfile:
+            raise http_exceptions.NotFound()
+
+        return flask.send_file(logfile, mimetype="text/plain")

--- a/backend/common/cephlcm_common/configs/defaults.yaml
+++ b/backend/common/cephlcm_common/configs/defaults.yaml
@@ -69,6 +69,7 @@ db:
   connect_timeout: 5000  # ms, 5 seconds
   socket_timeout: 5000  # ms, 5 seconds
   pool_size: 50
+  gridfs_chunk_size_in_bytes: 261120  # 255 kilobytes
 
 
 plugins:

--- a/backend/common/cephlcm_common/models/db.py
+++ b/backend/common/cephlcm_common/models/db.py
@@ -2,13 +2,19 @@
 """This module has db connection class."""
 
 
+import gridfs
+import gridfs.errors
 import pymongo
 
 from cephlcm_common import config
+from cephlcm_common import log
 
 
 CONF = config.make_config()
 """Config."""
+
+LOG = log.getLogger(__name__)
+"""Logger."""
 
 
 class MongoDB:
@@ -36,3 +42,33 @@ class MongoDB:
     @property
     def db(self):
         return self.client[self.dbname]
+
+
+class FileStorage:
+
+    COLLECTION = "fs"
+
+    def __init__(self, db):
+        self.fs = gridfs.GridFS(db, collection=self.COLLECTION)
+
+    def delete(self, key):
+        self.fs.delete(key)
+
+    def __contains__(self, key):
+        return self.fs.exists(key)
+
+    def get(self, key):
+        try:
+            return self.fs.get(key)
+        except (gridfs.errors.CorruptGridFile, gridfs.errors.NoFile) as exc:
+            LOG.warning("Cannot find file %s in collection %s: %s",
+                        key, self.COLLECTION, exc)
+
+    def new_file(self, key, filename=None, content_type=None):
+        kwargs = {"_id": key}
+        if filename is not None:
+            kwargs["filename"] = filename
+        if content_type is not None:
+            kwargs["content_type"] = content_type
+
+        return self.fs.new_file(**kwargs)

--- a/backend/common/cephlcm_common/models/db.py
+++ b/backend/common/cephlcm_common/models/db.py
@@ -64,11 +64,16 @@ class FileStorage:
             LOG.warning("Cannot find file %s in collection %s: %s",
                         key, self.COLLECTION, exc)
 
-    def new_file(self, key, filename=None, content_type=None):
+    def new_file(self, key, filename=None, content_type=None,
+                 chunk_size_bytes=None):
         kwargs = {"_id": key}
         if filename is not None:
             kwargs["filename"] = filename
         if content_type is not None:
             kwargs["content_type"] = content_type
+        if chunk_size_bytes is not None:
+            kwargs["chunk_size"] = chunk_size_bytes
+        else:
+            kwargs["chunk_size"] = CONF["db"]["gridfs_chunk_size_in_bytes"]
 
         return self.fs.new_file(**kwargs)

--- a/backend/common/cephlcm_common/models/execution.py
+++ b/backend/common/cephlcm_common/models/execution.py
@@ -6,6 +6,7 @@ configuration to execute and creates task for execution.
 """
 
 
+import contextlib
 import enum
 
 from cephlcm_common.models import db
@@ -48,21 +49,23 @@ class ExecutionModel(generic.Model):
         self.state = ExecutionState.created
 
     @property
+    @contextlib.contextmanager
     def logfile(self):
-        logfile = self.log_storage.get(self.execution_id)
+        logfile = self.log_storage.get(self.model_id)
         if not logfile:
             yield None
         with logfile:
             yield logfile
 
     @property
+    @contextlib.contextmanager
     def new_logfile(self):
         storage = self.log_storage()
-        storage.delete(self.execution_id)
+        storage.delete(self.model_id)
 
         new_file = storage.new_file(
-            self.execution_id,
-            filename="{0}.log".format(self.execution_id),
+            self.model_id,
+            filename="{0}.log".format(self.model_id),
             content_type="text/plain"
         )
         with new_file:

--- a/backend/common/cephlcm_common/models/execution.py
+++ b/backend/common/cephlcm_common/models/execution.py
@@ -6,7 +6,6 @@ configuration to execute and creates task for execution.
 """
 
 
-import contextlib
 import enum
 
 from cephlcm_common.models import db
@@ -49,27 +48,19 @@ class ExecutionModel(generic.Model):
         self.state = ExecutionState.created
 
     @property
-    @contextlib.contextmanager
     def logfile(self):
-        logfile = self.log_storage.get(self.model_id)
-        if not logfile:
-            yield None
-        with logfile:
-            yield logfile
+        return self.log_storage().get(self.model_id)
 
     @property
-    @contextlib.contextmanager
     def new_logfile(self):
         storage = self.log_storage()
         storage.delete(self.model_id)
 
-        new_file = storage.new_file(
+        return storage.new_file(
             self.model_id,
             filename="{0}.log".format(self.model_id),
             content_type="text/plain"
         )
-        with new_file:
-            yield new_file
 
     state = properties.ChoicesProperty("_state", ExecutionState)
 

--- a/backend/common/cephlcm_common/playbook_plugin.py
+++ b/backend/common/cephlcm_common/playbook_plugin.py
@@ -26,7 +26,6 @@ except ImportError:
 from cephlcm_common import config
 from cephlcm_common import exceptions
 from cephlcm_common import log
-from cephlcm_common.models import execution
 from cephlcm_common.models import task
 
 
@@ -277,6 +276,8 @@ class Playbook(Base, metaclass=abc.ABCMeta):
         super().on_pre_execute(task)
 
     def on_post_execute(self, task, *exc_info):
+        from cephlcm_common.models import execution
+
         self.PROCESS_STDOUT.seek(0)
         try:
             execution_model = execution.ExecutionModel.find_by_model_id(

--- a/backend/common/cephlcm_common/playbook_plugin.py
+++ b/backend/common/cephlcm_common/playbook_plugin.py
@@ -6,6 +6,7 @@ import abc
 import contextlib
 import copy
 import functools
+import tempfile
 import ipaddress
 import operator
 import os


### PR DESCRIPTION
This PR adds support of plain text execution log files from Ansible. New API is `/v1/execution/{execution_id}/log/`.

A detail of implementation: GridFS is used to store these files. If we will move from Mongo oneday, we have to choose another shareable filestorage for logs.