### PR TITLE
Compact server list

### DIFF
--- a/shrimpcli/setup.py
+++ b/shrimpcli/setup.py
@@ -8,7 +8,8 @@ import setuptools
 REQUIREMENTS = (
     "shrimplib==0.1.0",
     "click>=6,<7",
-    "six>=1.10"
+    "six>=1.10",
+    "backports.csv"
 )
 
 

--- a/shrimpcli/shrimp_cli/decorators.py
+++ b/shrimpcli/shrimp_cli/decorators.py
@@ -152,7 +152,7 @@ def with_pagination(func):
         kwargs["query_params"] = query_params
 
         response = func(*args, **kwargs)
-        if no_envelope:
+        if no_envelope and response:
             response = response["items"]
 
         return response


### PR DESCRIPTION
One of the user's request: ability to show server list in compact view, eliminating a lot of details.

```shell
$ shrimp server get-all --compact                                      
"machine_id","version","fqdn","username","default_ip","interface=mac=ipv4=ipv6","..."
"0f26c53a-4ce6-4fdd-9e4b-ed7400abf8eb","4","keen-skunk.maas","ansible","10.10.0.7","ens3=52:54:00:36:85:df=10.10.0.7=fe80::5054:ff:fe36:85df"
"3ee25709-215d-4f51-8348-20b4e7390fdb","4","modest-gator.maas","ansible","10.10.0.2","ens3=52:54:00:09:c8:e2=10.10.0.2=fe80::5054:ff:fe09:c8e2"
"6cafad99-6353-448c-afbc-f161d0664522","4","subtle-pig.maas","ansible","10.10.0.3","ens3=52:54:00:e8:90:b8=10.10.0.3=fe80::5054:ff:fee8:90b8"
"73079fc7-58a8-40b0-ba03-f02d7a4f2817","4","valued-sheep.maas","ansible","10.10.0.4","ens3=52:54:00:bd:dc:84=10.10.0.4=fe80::5054:ff:febd:dc84"
```