### PR TITLE
DEB packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,6 @@ ssl.key
 ssl.crt
 ssl-dhparam.pem
 config.yaml
+deb_dist
+mongodb-ca.crt
+mongodb.pem

--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,9 @@ build_deb_ansible: clean_debs make_deb_directory
 build_deb_common: clean_debs make_deb_directory
 	$(call build_deb_py3,"$(ROOT_DIR)/backend/common","$(DEB_DIR)")
 
+build_deb_controller: clean_debs make_deb_directory
+	$(call build_deb_py3,"$(ROOT_DIR)/backend/controller","$(DEB_DIR)")
+
 
 clean_debs:
 	rm -rf "$(DEB_DIR)"

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,12 @@ make_output_directory:
 
 # -----------------------------------------------------------------------------
 
+build_debs: build_deb_shrimplib build_deb_shrimpcli build_deb_ansible \
+    build_deb_common build_deb_controller build_deb_api build_deb_migration \
+    build_deb_monitoring build_deb_emails build_deb_add_osd \
+    build_deb_deploy_cluster build_deb_helloworld build_deb_purge_cluster \
+    build_deb_remove_osd build_deb_server_discovery
+
 build_deb_shrimplib: clean_debs make_deb_directory
 	$(call build_deb_universal,"$(ROOT_DIR)/shrimplib","$(DEB_DIR)")
 

--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,9 @@ build_deb_controller: clean_debs make_deb_directory
 build_deb_api: clean_debs make_deb_directory
 	$(call build_deb_py3,"$(ROOT_DIR)/backend/api","$(DEB_DIR)")
 
+build_deb_migration: clean_debs make_deb_directory
+	$(call build_deb_py3,"$(ROOT_DIR)/backend/migration","$(DEB_DIR)")
+
 
 clean_debs:
 	rm -rf "$(DEB_DIR)"

--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,9 @@ build_deb_api: clean_debs make_deb_directory
 build_deb_migration: clean_debs make_deb_directory
 	$(call build_deb_py3,"$(ROOT_DIR)/backend/migration","$(DEB_DIR)")
 
+build_deb_monitoring: clean_debs make_deb_directory
+	$(call build_deb_py2,"$(ROOT_DIR)/backend/monitoring","$(DEB_DIR)")
+
 
 clean_debs:
 	rm -rf "$(DEB_DIR)"

--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,9 @@ build_deb_migration: clean_debs make_deb_directory
 build_deb_monitoring: clean_debs make_deb_directory
 	$(call build_deb_py2,"$(ROOT_DIR)/backend/monitoring","$(DEB_DIR)")
 
+build_deb_emails: clean_debs make_deb_directory
+	$(call build_deb_py3,"$(ROOT_DIR)/plugins/alerts/emails","$(DEB_DIR)")
+
 
 clean_debs:
 	rm -rf "$(DEB_DIR)"

--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,23 @@ build_deb_monitoring: clean_debs make_deb_directory
 build_deb_emails: clean_debs make_deb_directory
 	$(call build_deb_py3,"$(ROOT_DIR)/plugins/alerts/emails","$(DEB_DIR)")
 
+build_deb_add_osd: clean_debs make_deb_directory
+	$(call build_deb_py3,"$(ROOT_DIR)/plugins/playbook/add_osd","$(DEB_DIR)")
+
+build_deb_deploy_cluster: clean_debs make_deb_directory
+	$(call build_deb_py3,"$(ROOT_DIR)/plugins/playbook/deploy_cluster","$(DEB_DIR)")
+
+build_deb_helloworld: clean_debs make_deb_directory
+	$(call build_deb_py3,"$(ROOT_DIR)/plugins/playbook/playbook_helloworld","$(DEB_DIR)")
+
+build_deb_purge_cluster: clean_debs make_deb_directory
+	$(call build_deb_py3,"$(ROOT_DIR)/plugins/playbook/purge_cluster","$(DEB_DIR)")
+
+build_deb_remove_osd: clean_debs make_deb_directory
+	$(call build_deb_py3,"$(ROOT_DIR)/plugins/playbook/remove_osd","$(DEB_DIR)")
+
+build_deb_server_discovery: clean_debs make_deb_directory
+	$(call build_deb_py3,"$(ROOT_DIR)/plugins/playbook/server_discovery","$(DEB_DIR)")
 
 clean_debs:
 	rm -rf "$(DEB_DIR)"

--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,9 @@ build_deb_common: clean_debs make_deb_directory
 build_deb_controller: clean_debs make_deb_directory
 	$(call build_deb_py3,"$(ROOT_DIR)/backend/controller","$(DEB_DIR)")
 
+build_deb_api: clean_debs make_deb_directory
+	$(call build_deb_py3,"$(ROOT_DIR)/backend/api","$(DEB_DIR)")
+
 
 clean_debs:
 	rm -rf "$(DEB_DIR)"

--- a/Makefile
+++ b/Makefile
@@ -35,11 +35,11 @@ define build_deb_universal
 endef
 
 define build_deb_py2
-    $(call build_deb,--with-python2=True --with-python3=False --xs-python-version='>=2.7',$(1),$(2))
+    $(call build_deb,--with-python2=True --with-python3=False,$(1),$(2))
 endef
 
 define build_deb_py3
-    $(call build_deb,--with-python2=False --with-python3=True --x-python3-version='>=3.4',$(1),$(2))
+    $(call build_deb,--with-python2=False --with-python3=True,$(1),$(2))
 endef
 
 define dump_image
@@ -65,11 +65,18 @@ make_output_directory:
 
 # -----------------------------------------------------------------------------
 
-build_deb_shrimplib: make_deb_directory
+build_deb_shrimplib: clean_debs make_deb_directory
 	$(call build_deb_universal,"$(ROOT_DIR)/shrimplib","$(DEB_DIR)")
 
-build_deb_shrimpcli: make_deb_directory
+build_deb_shrimpcli: clean_debs make_deb_directory
 	$(call build_deb_universal,"$(ROOT_DIR)/shrimpcli","$(DEB_DIR)")
+
+build_deb_ansible: clean_debs make_deb_directory
+	$(call build_deb_py2,"$(ROOT_DIR)/backend/ansible","$(DEB_DIR)")
+
+
+clean_debs:
+	rm -rf "$(DEB_DIR)"
 
 # -----------------------------------------------------------------------------
 

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,9 @@ build_deb_shrimpcli: clean_debs make_deb_directory
 build_deb_ansible: clean_debs make_deb_directory
 	$(call build_deb_py2,"$(ROOT_DIR)/backend/ansible","$(DEB_DIR)")
 
+build_deb_common: clean_debs make_deb_directory
+	$(call build_deb_py3,"$(ROOT_DIR)/backend/common","$(DEB_DIR)")
+
 
 clean_debs:
 	rm -rf "$(DEB_DIR)"

--- a/backend/ansible/stdeb.cfg
+++ b/backend/ansible/stdeb.cfg
@@ -1,0 +1,2 @@
+[DEFAULT]
+XS-Python-Version: >= 2.7

--- a/backend/api/stdeb.cfg
+++ b/backend/api/stdeb.cfg
@@ -1,3 +1,3 @@
 [DEFAULT]
 X-Python3-Version: >= 3.4
-Depends3: python3-shrimp-common
+Depends3: python3-shrimp-common (>= 0.1), python3-shrimp-common (<< 0.2)

--- a/backend/api/stdeb.cfg
+++ b/backend/api/stdeb.cfg
@@ -1,0 +1,3 @@
+[DEFAULT]
+X-Python3-Version: >= 3.4
+Depends3: python3-shrimp-common

--- a/backend/common/stdeb.cfg
+++ b/backend/common/stdeb.cfg
@@ -1,0 +1,3 @@
+[DEFAULT]
+X-Python3-Version: >= 3.4
+Depends3: python3-argon2-cffi

--- a/backend/controller/stdeb.cfg
+++ b/backend/controller/stdeb.cfg
@@ -1,3 +1,3 @@
 [DEFAULT]
 X-Python3-Version: >= 3.4
-Depends3: python3-shrimp-common
+Depends3: python3-shrimp-common (>= 0.1), python3-shrimp-common (<< 0.2)

--- a/backend/controller/stdeb.cfg
+++ b/backend/controller/stdeb.cfg
@@ -1,0 +1,3 @@
+[DEFAULT]
+X-Python3-Version: >= 3.4
+Depends3: python3-shrimp-common

--- a/backend/migration/stdeb.cfg
+++ b/backend/migration/stdeb.cfg
@@ -1,3 +1,3 @@
 [DEFAULT]
 X-Python3-Version: >= 3.4
-Depends3: python3-shrimp-common
+Depends3: python3-shrimp-common (>= 0.1), python3-shrimp-common (<< 0.2)

--- a/backend/migration/stdeb.cfg
+++ b/backend/migration/stdeb.cfg
@@ -1,0 +1,3 @@
+[DEFAULT]
+X-Python3-Version: >= 3.4
+Depends3: python3-shrimp-common

--- a/backend/monitoring/stdeb.cfg
+++ b/backend/monitoring/stdeb.cfg
@@ -1,3 +1,3 @@
 [DEFAULT]
 XS-Python-Version: >= 2.7
-Depends: python-shrimp-ansible
+Depends: python-shrimp-ansible (>= 0.1), python-shrimp-ansible (<< 0.2)

--- a/backend/monitoring/stdeb.cfg
+++ b/backend/monitoring/stdeb.cfg
@@ -1,0 +1,3 @@
+[DEFAULT]
+XS-Python-Version: >= 2.7
+Depends: python-shrimp-ansible

--- a/devenv/roles/base/defaults/main.yaml
+++ b/devenv/roles/base/defaults/main.yaml
@@ -6,5 +6,6 @@ default_locale: en_US.UTF-8
 docker_keyserver: hkp://p80.pool.sks-keyservers.net:80
 docker_key: 58118E89F3A912897C070ADBF76221572C52609D
 docker_repo: deb https://apt.dockerproject.org/repo ubuntu-xenial main
-docker_version: 1.12.1-0~xenial
+docker_version: 1.12.3-0~xenial
 docker_compose_version: 1.8.1
+node_install_script: "https://deb.nodesource.com/setup_7.x"

--- a/devenv/roles/base/tasks/nodejs.yaml
+++ b/devenv/roles/base/tasks/nodejs.yaml
@@ -2,13 +2,13 @@
 # NodeJS and UI related stuff
 
 
-- name: Install typings
-  npm: name=typings global=yes
+- name: Install node 7x repository
+  become: true
+  shell: "curl -sL {{ node_install_script }} | bash -"
+
+- name: Install nodejs
+  become: true
+  apt: name=nodejs state=present
 
 - name: Install UI dependencies
   npm: path=/vagrant/ui
-
-- name: Install typings libraries into project
-  command: typings install chdir=/vagrant/ui
-  tags:
-    - skip_ansible_lint

--- a/devenv/roles/base/vars/main.yaml
+++ b/devenv/roles/base/vars/main.yaml
@@ -7,6 +7,7 @@ apt_packages:
   - aria2
   - build-essential
   - curl
+  - devscripts
   - emacs24-nox
   - exuberant-ctags
   - flake8
@@ -26,6 +27,9 @@ apt_packages:
   - libyaml-dev
   - ncurses-term
   - pkg-config
+  - python3-all
+  - python3-all-dev
+  - python3-cffi
   - python3-flake8
   - python3-hacking
   - python3-ipdb
@@ -33,8 +37,12 @@ apt_packages:
   - python3-pep8
   - python3-pep8-naming
   - python3-pip
+  - python3-stdeb
   - python3-virtualenv
+  - python-all
+  - python-all-dev
   - python-autopep8
+  - python-cffi
   - python-dev
   - python-flake8
   - python-hacking
@@ -43,6 +51,7 @@ apt_packages:
   - python-pep8
   - python-pep8-naming
   - python-pip
+  - python-stdeb
   - python-virtualenv
   - ruby
   - shellcheck

--- a/devenv/roles/base/vars/main.yaml
+++ b/devenv/roles/base/vars/main.yaml
@@ -25,9 +25,6 @@ apt_packages:
   - libxslt-dev
   - libyaml-dev
   - ncurses-term
-  - nodejs
-  - nodejs-legacy
-  - npm
   - pkg-config
   - python3-flake8
   - python3-hacking

--- a/devenv/roles/python/tasks/pythons.yaml
+++ b/devenv/roles/python/tasks/pythons.yaml
@@ -33,9 +33,9 @@
            chdir=/vagrant
   with_items:
     - backend/common
+    - backend/migration
     - backend/api
     - backend/controller
-    - backend/migration
     - plugins/alerts/emails
     - plugins/playbook/server_discovery
     - plugins/playbook/playbook_helloworld

--- a/devenv/roles/sarkhipov/tasks/tmux.yaml
+++ b/devenv/roles/sarkhipov/tasks/tmux.yaml
@@ -9,7 +9,7 @@
     - skip_ansible_lint
 
 - name: Download tmux with truecolor support
-  get_url: url=http://ftp.ru.debian.org/debian/pool/main/t/tmux/tmux_2.2-3_amd64.deb
+  get_url: url=http://ftp.ru.debian.org/debian/pool/main/t/tmux/tmux_2.3-4_amd64.deb
            dest=/tmp/tmux.deb
   when: tmux_version.stdout.find("2.2") == -1
 

--- a/plugins/alerts/emails/stdeb.cfg
+++ b/plugins/alerts/emails/stdeb.cfg
@@ -1,3 +1,3 @@
 [DEFAULT]
 X-Python3-Version: >= 3.4
-Depends3: python3-shrimp-common
+Depends3: python3-shrimp-common (>= 0.1), python3-shrimp-common (<< 0.2)

--- a/plugins/alerts/emails/stdeb.cfg
+++ b/plugins/alerts/emails/stdeb.cfg
@@ -1,0 +1,3 @@
+[DEFAULT]
+X-Python3-Version: >= 3.4
+Depends3: python3-shrimp-common

--- a/plugins/playbook/__template__/{{cookiecutter.plugin_name}}/stdeb.cfg
+++ b/plugins/playbook/__template__/{{cookiecutter.plugin_name}}/stdeb.cfg
@@ -1,0 +1,3 @@
+[DEFAULT]
+X-Python3-Version: >= 3.4
+Depends3: python3-shrimp-common

--- a/plugins/playbook/add_osd/stdeb.cfg
+++ b/plugins/playbook/add_osd/stdeb.cfg
@@ -1,3 +1,3 @@
 [DEFAULT]
 X-Python3-Version: >= 3.4
-Depends3: python3-shrimp-common
+Depends3: python3-shrimp-common (>= 0.1), python3-shrimp-common (<< 0.2)

--- a/plugins/playbook/add_osd/stdeb.cfg
+++ b/plugins/playbook/add_osd/stdeb.cfg
@@ -1,0 +1,3 @@
+[DEFAULT]
+X-Python3-Version: >= 3.4
+Depends3: python3-shrimp-common

--- a/plugins/playbook/deploy_cluster/stdeb.cfg
+++ b/plugins/playbook/deploy_cluster/stdeb.cfg
@@ -1,3 +1,3 @@
 [DEFAULT]
 X-Python3-Version: >= 3.4
-Depends3: python3-shrimp-common
+Depends3: python3-shrimp-common (>= 0.1), python3-shrimp-common (<< 0.2)

--- a/plugins/playbook/deploy_cluster/stdeb.cfg
+++ b/plugins/playbook/deploy_cluster/stdeb.cfg
@@ -1,0 +1,3 @@
+[DEFAULT]
+X-Python3-Version: >= 3.4
+Depends3: python3-shrimp-common

--- a/plugins/playbook/playbook_helloworld/stdeb.cfg
+++ b/plugins/playbook/playbook_helloworld/stdeb.cfg
@@ -1,3 +1,3 @@
 [DEFAULT]
 X-Python3-Version: >= 3.4
-Depends3: python3-shrimp-common
+Depends3: python3-shrimp-common (>= 0.1), python3-shrimp-common (<< 0.2)

--- a/plugins/playbook/playbook_helloworld/stdeb.cfg
+++ b/plugins/playbook/playbook_helloworld/stdeb.cfg
@@ -1,0 +1,3 @@
+[DEFAULT]
+X-Python3-Version: >= 3.4
+Depends3: python3-shrimp-common

--- a/plugins/playbook/purge_cluster/stdeb.cfg
+++ b/plugins/playbook/purge_cluster/stdeb.cfg
@@ -1,3 +1,3 @@
 [DEFAULT]
 X-Python3-Version: >= 3.4
-Depends3: python3-shrimp-common
+Depends3: python3-shrimp-common (>= 0.1), python3-shrimp-common (<< 0.2)

--- a/plugins/playbook/purge_cluster/stdeb.cfg
+++ b/plugins/playbook/purge_cluster/stdeb.cfg
@@ -1,0 +1,3 @@
+[DEFAULT]
+X-Python3-Version: >= 3.4
+Depends3: python3-shrimp-common

--- a/plugins/playbook/remove_osd/stdeb.cfg
+++ b/plugins/playbook/remove_osd/stdeb.cfg
@@ -1,3 +1,3 @@
 [DEFAULT]
 X-Python3-Version: >= 3.4
-Depends3: python3-shrimp-common
+Depends3: python3-shrimp-common (>= 0.1), python3-shrimp-common (<< 0.2)

--- a/plugins/playbook/remove_osd/stdeb.cfg
+++ b/plugins/playbook/remove_osd/stdeb.cfg
@@ -1,0 +1,3 @@
+[DEFAULT]
+X-Python3-Version: >= 3.4
+Depends3: python3-shrimp-common

--- a/plugins/playbook/server_discovery/stdeb.cfg
+++ b/plugins/playbook/server_discovery/stdeb.cfg
@@ -1,3 +1,3 @@
 [DEFAULT]
 X-Python3-Version: >= 3.4
-Depends3: python3-shrimp-common
+Depends3: python3-shrimp-common (>= 0.1), python3-shrimp-common (<< 0.2)

--- a/plugins/playbook/server_discovery/stdeb.cfg
+++ b/plugins/playbook/server_discovery/stdeb.cfg
@@ -1,0 +1,3 @@
+[DEFAULT]
+X-Python3-Version: >= 3.4
+Depends3: python3-shrimp-common

--- a/shrimpcli/stdeb.cfg
+++ b/shrimpcli/stdeb.cfg
@@ -1,5 +1,5 @@
 [DEFAULT]
 XS-Python-Version: >= 2.7
 X-Python3-Version: >= 3.4
-Depends: python-backports.csv, python-shrimplib
-Depends3: python3-shrimplib
+Depends: python-backports.csv, python-shrimplib (>= 0.1), python-shrimplib (<< 0.2)
+Depends3: python3-shrimplib (>= 0.1), python3-shrimplib (<< 0.2)

--- a/shrimpcli/stdeb.cfg
+++ b/shrimpcli/stdeb.cfg
@@ -1,0 +1,4 @@
+[DEFAULT]
+XS-Python-Version: >= 2.7
+X-Python3-Version: >= 3.4
+Depends: python-backports.csv

--- a/shrimpcli/stdeb.cfg
+++ b/shrimpcli/stdeb.cfg
@@ -1,4 +1,5 @@
 [DEFAULT]
 XS-Python-Version: >= 2.7
 X-Python3-Version: >= 3.4
-Depends: python-backports.csv
+Depends: python-backports.csv, python-shrimplib
+Depends3: python3-shrimplib

--- a/shrimplib/stdeb.cfg
+++ b/shrimplib/stdeb.cfg
@@ -1,0 +1,5 @@
+[DEFAULT]
+XS-Python-Version: >= 2.7
+X-Python3-Version: >= 3.4
+Suggests: python-shrimp-cli (>= 0.1.0), python-shrimp-cli (<< 0.2)
+Suggests3: python3-shrimp-cli (>= 0.1.0), python3-shrimp-cli (<< 0.2)


### PR DESCRIPTION
This PR brings abilities to build DEB packages for Decapod. To do so, execute `make build_debs`.

Please be noticed, that preliminary packages should be installed:

```shell
$ sudo apt-get install python3-all-dev python3-all python-all-dev python-all devscripts python3-cffi python-cffi python3-stdeb python-stdeb
```

Please be noticed, that you should install `stdeb` from default repository, not from PyPI.