### PR TITLE
Create decapod-migrations container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ CONTAINER_DB_NAME         := decapod-db
 CONTAINER_DB_DATA_NAME    := decapod-db-data
 CONTAINER_FRONTEND_NAME   := decapod-frontend
 CONTAINER_PLUGINS_NAME    := decapod-base-plugins
+CONTAINER_MIGRATIONS_NAME := decapod-migrations
 
 # -----------------------------------------------------------------------------
 
@@ -237,7 +238,9 @@ clean_ui:
 # -----------------------------------------------------------------------------
 
 
-build_containers: build_container_api build_container_controller build_container_frontend build_container_db build_container_db_data build_container_cron
+build_containers: build_container_api build_container_controller \
+	build_container_frontend build_container_db build_container_db_data \
+	build_container_cron build_container_migrations
 build_containers_dev: copy_example_keys build_containers
 
 build_container_api: build_container_plugins
@@ -267,10 +270,14 @@ build_container_base: build_eggs
 build_container_plugins: build_container_base
 	docker build -f "$(ROOT_DIR)/containerization/backend-plugins.dockerfile" --tag $(CONTAINER_PLUGINS_NAME) --rm "$(ROOT_DIR)"
 
+build_container_migrations: build_container_plugins
+	docker build -f "$(ROOT_DIR)/containerization/migrations.dockerfile" --tag $(CONTAINER_MIGRATIONS_NAME) --rm "$(ROOT_DIR)"
+
 # -----------------------------------------------------------------------------
 
 
-dump_images: dump_image_api dump_image_controller dump_image_frontend dump_image_db dump_image_db_data dump_image_cron
+dump_images: dump_image_api dump_image_controller dump_image_frontend \
+	dump_image_db dump_image_db_data dump_image_cron dump_image_migrations
 
 dump_image_api: make_image_directory
 	$(call dump_image,$(CONTAINER_API_NAME),$(IMAGES_DIR))
@@ -289,6 +296,9 @@ dump_image_db_data: make_image_directory
 
 dump_image_cron: make_image_directory
 	$(call dump_image,$(CONTAINER_CRON_NAME),$(IMAGES_DIR))
+
+dump_image_migrations: make_image_directory
+	$(call dump_image,$(CONTAINER_MIGRATIONS_NAME),$(IMAGES_DIR))
 
 # -----------------------------------------------------------------------------
 

--- a/containerization/backend-api.dockerfile
+++ b/containerization/backend-api.dockerfile
@@ -23,7 +23,6 @@ RUN set -x \
     python3-dev \
     python3-pip \
   && pip3 install --compile --no-cache-dir --disable-pip-version-check -c /constraints.txt uwsgi \
-  && pip3 install --compile --no-cache-dir --disable-pip-version-check /eggs/decapod_migrations*.whl \
   && pip3 install --compile --no-cache-dir --disable-pip-version-check /eggs/decapod_api*.whl \
   && rm -r /eggs /constraints.txt \
   && apt-get clean \
@@ -35,4 +34,4 @@ RUN set -x \
 EXPOSE 8000
 
 ENTRYPOINT ["/usr/bin/dumb-init", "-c", "--"]
-CMD ["dockerize", "-wait", "tcp://database:27017", "--", "sh", "-c", "decapod-migrations apply && uwsgi /etc/decapod-api-uwsgi.ini"]
+CMD ["dockerize", "-wait", "tcp://database:27017", "--", "uwsgi", "/etc/decapod-api-uwsgi.ini"]

--- a/containerization/backend-api.dockerfile
+++ b/containerization/backend-api.dockerfile
@@ -35,4 +35,4 @@ RUN set -x \
 EXPOSE 8000
 
 ENTRYPOINT ["/usr/bin/dumb-init", "-c", "--"]
-CMD ["sh", "-c", "decapod-migrations apply && uwsgi /etc/decapod-api-uwsgi.ini"]
+CMD ["dockerize", "-wait", "tcp://database:27017", "--", "sh", "-c", "decapod-migrations apply && uwsgi /etc/decapod-api-uwsgi.ini"]

--- a/containerization/backend-base.dockerfile
+++ b/containerization/backend-base.dockerfile
@@ -23,6 +23,9 @@ RUN set -x \
   && wget --no-check-certificate https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64.deb \
   && dpkg -i dumb-init_1.2.0_amd64.deb \
   && rm dumb-init_*.deb \
+  && wget --no-check-certificate https://github.com/jwilder/dockerize/releases/download/v0.3.0/dockerize-linux-amd64-v0.3.0.tar.gz \
+  && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-v0.3.0.tar.gz \
+  && rm dockerize-linux-amd64-v0.3.0.tar.gz \
   && apt-get clean \
   && apt-get purge -y wget \
   && apt-get autoremove -y \

--- a/containerization/backend-controller.dockerfile
+++ b/containerization/backend-controller.dockerfile
@@ -39,4 +39,4 @@ RUN set -x \
 
 
 ENTRYPOINT ["/usr/bin/dumb-init", "-c", "--"]
-CMD ["decapod-controller"]
+CMD ["dockerize", "-wait", "tcp://database:27017", "--", "decapod-controller"]

--- a/containerization/backend-cron.dockerfile
+++ b/containerization/backend-cron.dockerfile
@@ -39,4 +39,4 @@ RUN set -x \
 
 EXPOSE 8000
 
-CMD ["sh", "-c", "caddy -conf '/etc/caddy/config' & cron && tail -F /var/log/cron.log"]
+CMD ["dockerize", "-wait", "tcp://database:27017", "--", "sh", "-c", "caddy -conf '/etc/caddy/config' & cron && tail -F /var/log/cron.log"]

--- a/containerization/frontend.dockerfile
+++ b/containerization/frontend.dockerfile
@@ -8,8 +8,18 @@ MAINTAINER Sergey Arkhipov <sarkhipov@mirantis.com>
 LABEL description="Base image with frontend for Decapod" version="0.2.0" vendor="Mirantis"
 
 
+RUN apk add --update ca-certificates openssl \
+  && update-ca-certificates \
+  && wget https://github.com/jwilder/dockerize/releases/download/v0.3.0/dockerize-linux-amd64-v0.3.0.tar.gz \
+  && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-v0.3.0.tar.gz \
+  && rm dockerize-linux-amd64-v0.3.0.tar.gz
+
+
 COPY containerization/files/nginx.conf /etc/nginx/nginx.conf
 COPY ssl.key /ssl/ssl.key
 COPY ssl.crt /ssl/ssl.crt
 COPY ssl-dhparam.pem /ssl/dhparam.pem
 COPY ui/build /static
+
+
+CMD ["dockerize", "-wait", "tcp://api:8000", "--", "nginx", "-g", "daemon off;"]

--- a/containerization/frontend.dockerfile
+++ b/containerization/frontend.dockerfile
@@ -8,7 +8,8 @@ MAINTAINER Sergey Arkhipov <sarkhipov@mirantis.com>
 LABEL description="Base image with frontend for Decapod" version="0.2.0" vendor="Mirantis"
 
 
-RUN apk add --update ca-certificates openssl \
+RUN set -x \
+  && apk add --update ca-certificates openssl \
   && update-ca-certificates \
   && wget https://github.com/jwilder/dockerize/releases/download/v0.3.0/dockerize-linux-amd64-v0.3.0.tar.gz \
   && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-v0.3.0.tar.gz \

--- a/containerization/migrations.dockerfile
+++ b/containerization/migrations.dockerfile
@@ -1,0 +1,35 @@
+# vi: set ft=dockerfile :
+
+
+
+FROM decapod-base-plugins
+MAINTAINER Sergey Arkhipov <sarkhipov@mirantis.com>
+
+
+LABEL description="Migration script for Decapod" version="0.2.0" vendor="Mirantis"
+
+
+COPY output/eggs /eggs
+
+
+RUN set -x \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends \
+      gcc \
+      libffi-dev \
+      python3-dev \
+      python3-pip \
+  && pip3 install --compile --no-cache-dir --disable-pip-version-check \
+      decapod_migrations*.whl \
+      decapod_api*.whl \
+      decapod_controller*.whl \
+      decapod_controller*.whl \
+  && rm -r /eggs \
+  && apt-get clean \
+  && apt-get purge -y libffi-dev python3-pip python3-dev gcc \
+  && apt-get autoremove -y \
+  && rm -r /var/lib/apt/lists/*
+
+
+ENTRYPOINT ["dockerize", "-wait", "tcp://database:27017", "--", "decapod-migrations"]
+CMD ["apply"]

--- a/containerization/migrations.dockerfile
+++ b/containerization/migrations.dockerfile
@@ -20,10 +20,10 @@ RUN set -x \
       python3-dev \
       python3-pip \
   && pip3 install --compile --no-cache-dir --disable-pip-version-check \
-      decapod_migrations*.whl \
-      decapod_api*.whl \
-      decapod_controller*.whl \
-      decapod_controller*.whl \
+      /eggs/decapod_migrations*.whl \
+      /eggs/decapod_api*.whl \
+      /eggs/decapod_controller*.whl \
+      /eggs/decapod_controller*.whl \
   && rm -r /eggs \
   && apt-get clean \
   && apt-get purge -y libffi-dev python3-pip python3-dev gcc \

--- a/containerization/migrations.dockerfile
+++ b/containerization/migrations.dockerfile
@@ -32,4 +32,3 @@ RUN set -x \
 
 
 ENTRYPOINT ["dockerize", "-wait", "tcp://database:27017", "--", "decapod-migrations"]
-CMD ["apply"]

--- a/scripts/migrate.sh
+++ b/scripts/migrate.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -eu -o pipefail
+
+
+while getopts ":h" opt; do
+  case $opt in
+    h)
+      echo "Run Decapod migrations."
+      echo ""
+      echo "This command runs decapod-migration CLI script, connected "
+      echo "to correct database"
+      echi "Use --help command to get help from CLI script."
+      echo ""
+      echo "${0} container_with_db_data command" >&2
+      exit 0
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      exit 1
+      ;;
+  esac
+done
+
+
+db_container="${1:-cephlcm_database_1}"
+command="${@:2}"
+
+docker run \
+    --rm \
+    -it \
+    --network "container:${db_container}" \
+    decapod-migrations $command


### PR DESCRIPTION
This PR removes `decapod-migration` script execution from decapod-api container. This is done because automatic execution of migration scripts may cause a lot of errors and this makes update really complex.

To execute migrations, there is new image called `migrate.sh` which runs `decapod-migration` within required container network.

Also, now all containers run commands through [dockerize](https://github.com/jwilder/dockerize).