### PR TITLE
Make fetching of execution log streamable

### DIFF
--- a/decapodcli/decapodcli/execution.py
+++ b/decapodcli/decapodcli/execution.py
@@ -97,9 +97,10 @@ def log(ctx, execution_id, client):
     execution."""
 
     response = client.get_execution_log(execution_id,
-                                        headers={"Content-Type": "text/plain"})
-
+                                        headers={"Content-Type": "text/plain"},
+                                        raw_response=True, stream=True)
     if ctx.obj["pager"]:
-        click.echo_via_pager(response)
+        click.echo_via_pager(response.text)
     else:
-        click.echo(response)
+        for line in response.iter_lines(decode_unicode=True):
+            click.echo(line)

--- a/decapodlib/decapodlib/client.py
+++ b/decapodlib/decapodlib/client.py
@@ -143,7 +143,10 @@ def json_response(func):
 
     @six.wraps(func)
     def decorator(*args, **kwargs):
+        raw_response = kwargs.pop("raw_response", False)
         response = func(*args, **kwargs)
+        if raw_response:
+            return response
 
         if isinstance(response, dict):
             return response


### PR DESCRIPTION
As practice shows, execution log could be rather big so this PR allows to make it streamable to terminal using CLI.

Also, it adds new `raw_response` parameter to decapod client. This parameter means that we want to get raw response from API, not parsed at all, as is.