### PR TITLE
Fix for building backend-admin image

### DIFF
--- a/containerization/backend-admin.dockerfile
+++ b/containerization/backend-admin.dockerfile
@@ -56,6 +56,7 @@ RUN set -x \
     libpython2.7 \
     libssl-dev \
     libtool \
+    locales \
     make \
     mongodb-org-tools \
     nano \


### PR DESCRIPTION
Added missing package 'locales', which is required for locale-gen